### PR TITLE
#50: python-publish gh workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,29 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        CIRRUS_VERSION: ${{ github.event.release.tag_name }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_APIKEY }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- bumped rasterio to 1.2.8
+
+## [v0.5.0a0] - 2021-10-04
+
+Now a python package that installs a `cirrus` cli tool to manage cirrus
+projects. Existing projects are supported with some manual migration/cleanup
+steps.
+
+- bumped rasterio version to 1.2.8 where applicable
 
 ## [v0.4.2] - 2021-01-12
 
@@ -116,6 +123,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Initial release
 
 [Unreleased]: https://github.com/cirrus-geo/cirrus/compare/v0.4.2...main
+[v0.5.0a0]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.4.2...v0.5.0a0
 [v0.4.2]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.4.1...v0.4.2
 [v0.4.1]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -10,34 +10,159 @@ As shown in this high-level overview of Cirrus, users input data to Cirrus throu
 
 Because Cirrus output is published via SNS, a Feeder can be configured to subscribe to that SNS and thus workflows can be chained, such that the output of one workflow becomes the input to another workflow and creates multiple levels of products, all with published STAC metadata and clear links showing data provenance.
 
+
+## Cirrus Quickstart
+
+A Cirrus project is managed via the `cirrus` cli tool. Here's everything required to create, modify, and deploy a new project:
+
+```
+# Make a new directory for a project
+❯ mkdir cirrus-project; cd cirrus-project
+
+# Create a python virtual environment for isolation
+❯ python -m venv .venv
+
+# Activate our venv
+❯ . .venv/bin/activate
+
+# Install cirrus-geo
+❯ pip install cirrus-geo
+...
+
+# Now we should have cirrus on our path
+❯ cirrus
+Usage: cirrus [OPTIONS] COMMAND [ARGS]...
+
+  cli for cirrus, a severless STAC-based processing pipeline
+
+Options:
+  --cirrus-dir DIRECTORY
+  -v, --verbose           Increase logging level. Can be specified multiple
+                          times.  [x>=0]
+  --help                  Show this message and exit.
+
+Commands:
+  build             Build the cirrus configuration into a serverless.yml.
+  clean             Remove all files from the cirrus build directory.
+  create            Create a new component in the project.
+  init              Initialize a cirrus project in DIRECTORY.
+  serverless (sls)  Run serverless within the cirrus build directory.
+  show              Multifunction command to list/show components,
+                    component...
+
+# Fantastic!
+# We can init our new project and see what all was created
+❯ cirrus init
+Succesfully initialized project in '/Users/jkeifer/cirrus-project'.
+
+❯ ls
+.venv/	cirrus.yml  feeders/  functions/  outputs/  package.json  resources/  tasks/  workflows/
+
+# The cirrus.yml is almost good to go for a minimal install,
+# but it does require a few parameters either set in the
+# config or as environment variables:
+#
+#   custom:
+#     batch:
+#       SecurityGroupIds:
+#         - ${env:SECURITY_GROUP_1}
+#       Subnets:
+#         - ${env:SUBNET_1}
+#         - ${env:SUBNET_2}
+#         - ${env:SUBNET_3}
+#         - ${env:SUBNET_4}
+#
+# Use your favorite editor to set these values approriately
+# based on your existing AWS resources.
+
+# As we do have node.js dependencies from serverless,
+# let's install those with the generated configuration
+❯ npm install
+...
+
+# We can see all the built in feeders, tasks, and workflows (among others)
+❯ cirrus show feeders
+feed-rerun (built-in): Rerun items in the database
+feed-s3-inventory (built-in): Feed Sentinel AWS inventory data to Cirrus for cataloging
+feed-stac-api (built-in): Feed data from a STAC API to Cirrus for processing
+feed-stac-crawl (built-in): Crawl static STAC assets
+
+❯ cirrus show tasks
+add-preview (built-in, lambda): Create a preview and/or thumbnail from one or more assets
+convert-to-cog (built-in, lambda): Convert specified assets into Cloud Optimized GeoTIFFs
+copy-assets (built-in, lambda): Copy specified assets from Item(s) to an S3 bucket
+post-batch (built-in, lambda): Post process batch job by copying input from S3
+pre-batch (built-in, lambda): Pre process batch job by copying input to S3
+publish (built-in, lambda): Publish resulting STAC Collections and Items to catalog, and optionally SNS
+
+❯ cirrus show workflows
+cog-archive (built-in): Create mirror with some cogified assets
+mirror (built-in): Mirror items with selected assets
+mirror-with-preview (built-in): Mirror items with selected assets
+publish-only (built-in): Simple example that just published input Collections and items
+
+# To create a new task, for example, we can do this
+❯ cirrus create task a_task "A task that doesn't do much yet"
+task a_task created
+
+❯ cirrus show tasks
+add-preview (built-in, lambda): Create a preview and/or thumbnail from one or more assets
+convert-to-cog (built-in, lambda): Convert specified assets into Cloud Optimized GeoTIFFs
+copy-assets (built-in, lambda): Copy specified assets from Item(s) to an S3 bucket
+post-batch (built-in, lambda): Post process batch job by copying input from S3
+pre-batch (built-in, lambda): Pre process batch job by copying input to S3
+publish (built-in, lambda): Publish resulting STAC Collections and Items to catalog, and optionally SNS
+a_task (lambda): A task that doesn't do much yet
+
+# We can see that created a task and its
+# associated config inside the tasks directory
+❯ tree tasks
+tasks
+└── a_task
+    ├── README.md
+    ├── definition.yml
+    └── lambda_function.py
+
+# To build our configuration in to something
+# compatible with serverless, we use the build command
+❯ cirrus build
+
+# The output of build is in the .cirrus directory
+❯ ls .cirrus
+lambdas/  serverless.yml
+
+# To deploy with serverless, we can simply do the following
+# (optionally set the stage with `--stage <stage_name>`)
+❯ cirrus serverless deploy
+```
+
+
+## Cirrus Project Structure
+
+A Cirrus project, most basically, is a directory containing a cirrus.yml configuration file. However, several subfolders are used to organize additional object definitions for custom implementations.
+
+| Folder     | Purpose |
+|:-----------|---------|
+| feeders    | Feeder Lambda functions used to add data to Cirrus |
+| functions  | Misc Lambda functions required by a project |
+| outputs    | Cloudformation output templates |
+| resources  | Cloudformation resource templates |
+| tasks      | Task Lambda function used within workflows |
+| workflows  | AWS Step Function definitions describing data processing workflows |
+
+
 ## Cirrus Repositories
 
-Cirrus is divided up into several repositories, all under the [cirrus-geo](https://github.com/cirrus-geo) organization on GitHub, with this repository (`cirrus`) the main one of interest to users.
+Cirrus is divided up into several repositories, all under the [cirrus-geo](https://github.com/cirrus-geo) organization on GitHub, with this repository (`cirrus-geo`) the main one of interest to users.
 
 | Repository         | Purpose |
 |:------------------ |---------|
-| cirrus             | Main Cirrus repo containing serverless config and deployment files, along with the standard set of Lambda functions |
+| cirrus-geo         | Main Cirrus repo implementing the `cirrus` cli tool for managing Cirrus projects. Also provides the base set of lambda functions and workflows.
 | [cirrus-lib](https://github.com/cirrus-geo/cirrus-lib) | A Python library of convenience functions to interact with Cirrus. Lambda functions are kept lightweight |
 | [cirrus-task-images](https://github.com/cirrus-geo/cirrus-task-images)  | Dockerfiles and code for publishing Cirrus Docker images to Docker Hub that are used in Cirrus Batch tasks |
 
-The `cirrus` repository is what users would clone, modify and deploy. The pip-installable python library `cirrus-lib` is used from all Cirrus Lambdas and tasks and is available to developers for writing their own tasks.
+The `cirrus` cli utilitiy is what is used to create, manage, and deploy Cirrus projects, and is pip-installable. The pip-installable python library `cirrus-lib` is used from all Cirrus Lambdas and tasks and is available to developers for writing their own tasks.
 
-## Cirrus Repository Structure
-
-This repository, `cirrus` contains  all the files for deploying a Cirrus instance including all the core Lambda functions, workflows (AWS Step Functions), State database (AWS DynamoDB), Compute Environments (AWS Batch), and API (API Gateway + Lambda).
-
-Users may need to edit the deployment YAML files as needed for their Cirrus instance, and may also wish to add new tasks, Lambda functions, and workflows.
-
-| Folder    | Purpose |
-|:----------|---------|
-| core      | Core lambda functions for validating and orchestrating workflows |
-| deploy    | yaml files used for deployment with Serverless (referenced from [serverless.yml](serverless.yml)) |
-| docs      | Keeping details documentation for this application in a single place |
-| feeders   | Feeder Lambda functions used to add data to Cirrus |
-| lambdas   | Code for lambdas |
-| tasks     | Lambda tasks |
-| test      | All test files for the application, including test fixtures, are kept here |
-| workflows | Definitions for AWS Step Functions and schemas |
 
 ## Documentation
 

--- a/cirrus/cli/components/base/component.py
+++ b/cirrus/cli/components/base/component.py
@@ -254,7 +254,7 @@ class Component(metaclass=ComponentMeta):
                 f"Component {cls.type} does not support creation"
             )
         path = cls.user_dir.joinpath(name)
-        return cls(path, load=False)
+        return cls(path, description, load=False)
 
     @classmethod
     def create(cls, name: str, description: str) -> Type[T]:

--- a/cirrus/cli/components/files/definitions.py
+++ b/cirrus/cli/components/files/definitions.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 # TODO: figure out most basic permissions
-lambda_base = '''description: '{description}'
+lambda_base = '''description: {description}
 iamRoleStatements: []
 python_requirements: []
 environment: {{}}

--- a/cirrus/cli/utils/misc.py
+++ b/cirrus/cli/utils/misc.py
@@ -11,7 +11,7 @@ def get_cirrus_lib_requirement() -> str:
     except ImportError:
         import importlib_metadata as metadata
 
-    package_name = __package__.split('.')[0]
+    package_name = 'cirrus-geo'
     return [
         req for req in metadata.requires(package_name)
         if req.startswith('cirrus-lib')

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ package_data = {
 
 
 setup(
-    name='cirrus',
+    name='cirrus-geo',
     packages=find_namespace_packages(exclude=['docs', 'test*']),
     version=VERSION,
     description=DESC,


### PR DESCRIPTION
We'll need to make sure the secrets are configured for this to work, but here is an initial pypi publish workflow. The version used for the release is set by the tag name, so simply name a release with a version like "v1.2.3" and that'll be the version used in the package.