### PR TITLE
ensure lambdas are packaged completely separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [v0.5.0a0] - 2021-10-04
+## [v0.5.0a1] - 2021-10-05
+
+- Separate lambda packages only contain code/files specific to each respective lambda
+
+## [v0.5.0a0] - 2021-10-05
 
 Now a python package that installs a `cirrus` cli tool to manage cirrus
 projects. Existing projects are supported with some manual migration/cleanup
@@ -123,6 +127,7 @@ steps.
 Initial release
 
 [Unreleased]: https://github.com/cirrus-geo/cirrus/compare/v0.4.2...main
+[v0.5.0a1]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.5.0a0...v0.5.0a1
 [v0.5.0a0]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.4.2...v0.5.0a0
 [v0.4.2]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.4.1...v0.4.2
 [v0.4.1]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.4.0...v0.4.1

--- a/cirrus/cli/components/base/_lambda.py
+++ b/cirrus/cli/components/base/_lambda.py
@@ -35,6 +35,10 @@ class Lambda(Component):
         if self.project and self.project.config:
             self.lambda_config.environment.update(self.project.config.provider.environment)
 
+        self.lambda_config.package = {}
+        self.lambda_config.package.include = []
+        self.lambda_config.package.include.append(f'./lambdas/{self.name}/**')
+
         if not hasattr(self.lambda_config, 'module'):
             self.lambda_config.module = f'lambdas/{self.name}'
         if not hasattr(self.lambda_config, 'handler'):

--- a/cirrus/cli/config/__init__.py
+++ b/cirrus/cli/config/__init__.py
@@ -37,6 +37,11 @@ class Config(NamedYamlable):
             Outputs={},
         )
 
+        self.package = {}
+        self.package.individually = True
+        self.package.exclude = []
+        self.package.exclude.append('**/*')
+
         # populate required plugin list
         try:
             self.plugins.extend(SERVERLESS_PLUGINS.keys())

--- a/cirrus/cli/config/default.yml
+++ b/cirrus/cli/config/default.yml
@@ -132,6 +132,3 @@ custom:
       - 'urllib3-*/**'
       - 'jmespath/**'
       - 'jmespath-*/**'
-
-package:
-  individually: true

--- a/tests/fixture_data/build/lambdas/add-preview/requirements.txt
+++ b/tests/fixture_data/build/lambdas/add-preview/requirements.txt
@@ -1,3 +1,3 @@
-rasterio==1.1.3
+rasterio==1.2.8
 rio-cogeo~=1.1.10
 cirrus-lib>=0.5.1

--- a/tests/fixture_data/build/lambdas/convert-to-cog/requirements.txt
+++ b/tests/fixture_data/build/lambdas/convert-to-cog/requirements.txt
@@ -1,3 +1,3 @@
-rasterio==1.1.3
+rasterio==1.2.8
 rio-cogeo~=1.1.10
 cirrus-lib>=0.5.1

--- a/tests/fixture_data/build/lambdas/post-batch/lambda_function.py
+++ b/tests/fixture_data/build/lambdas/post-batch/lambda_function.py
@@ -1,6 +1,33 @@
+import boto3
+import json
 from cirruslib import Catalog
 
+LOG_CLIENT = boto3.client('logs')
+
+class BaseException(Exception):
+    pass
 
 def lambda_handler(payload, context):
+    if 'error' in payload:
+        error = payload.get('error', {})
+        cause = json.loads(error['Cause'])
+        reason = cause['Attempts'][-1]['StatusReason']
+        logname = cause['Attempts'][-1]['Container']['LogStreamName']
+        error_type, error_msg = get_error_from_batch(logname)
+        exception_class = type(error_type, (BaseException, Exception), {})
+        raise exception_class(error_msg)
     catalog = Catalog.from_payload(payload)
     return catalog
+
+def get_error_from_batch(logname):
+    try:
+        logs = LOG_CLIENT.get_log_events(logGroupName='/aws/batch/job', logStreamName=logname)
+        msg = logs['events'][-1]['message'].lstrip('cirruslib.errors.')
+        parts = msg.split(':', maxsplit=1)
+        if len(parts) > 1:
+            error_type = parts[0]
+            msg = parts[1]
+            return error_type, msg
+        return "Unknown", msg
+    except Exception:
+        return "Exception", "Unable to get Error Log"

--- a/tests/fixture_data/build/lambdas/update-state/lambda_function.py
+++ b/tests/fixture_data/build/lambdas/update-state/lambda_function.py
@@ -17,7 +17,6 @@ INVALID_TOPIC_ARN = getenv('CIRRUS_INVALID_TOPIC_ARN', None)
 
 # boto3 clients
 SNS_CLIENT = boto3.client('sns')
-LOG_CLIENT = boto3.client('logs')
 SFN_CLIENT = boto3.client('stepfunctions')
 
 # Cirrus state database
@@ -51,16 +50,6 @@ def workflow_failed(catalog, error):
         error_msg = 'unknown'
         if 'errorMessage' in cause:
             error_msg = cause.get('errorMessage', 'unknown')
-        elif 'Attempts' in cause:
-            try:
-                # batch
-                reason = cause['Attempts'][-1]['StatusReason']
-                if 'Essential container in task exited' in reason:
-                    # get the message from batch logs
-                    logname = cause['Attempts'][-1]['Container']['LogStreamName']
-                    error_type, error_msg = get_error_from_batch(logname)
-            except Exception as err:
-                logger.error(err, exc_info=True)
     except Exception:
         error_msg = error['Cause']
 
@@ -180,21 +169,6 @@ def parse_payload(payload):
     except Exception:
         logger.error('Unknown payload: %s', json.dumps(payload))
         return None, None, None
-
-
-def get_error_from_batch(logname):
-    try:
-        logs = LOG_CLIENT.get_log_events(logGroupName='/aws/batch/job', logStreamName=logname)
-        msg = logs['events'][-1]['message'].lstrip('cirruslib.errors.')
-        parts = msg.split(':', maxsplit=1)
-        if len(parts) > 1:
-            error_type = parts[0]
-            msg = parts[1]
-            return error_type, msg
-        return "Unknown", msg
-    except Exception:
-        return "Exception", "Unable to get Error Log"
-
 
 def lambda_handler(payload, context={}):
     logger.debug(payload)

--- a/tests/fixture_data/build/serverless.yml
+++ b/tests/fixture_data/build/serverless.yml
@@ -136,8 +136,6 @@ custom:
       - urllib3-*/**
       - jmespath/**
       - jmespath-*/**
-package:
-  individually: true
 functions:
   api:
     memorySize: 128
@@ -166,6 +164,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/api/**
     module: lambdas/api
     handler: lambda_function.lambda_handler
   process:
@@ -194,6 +195,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/process/**
     module: lambdas/process
     handler: lambda_function.lambda_handler
   publish-test:
@@ -218,6 +222,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/publish-test/**
     module: lambdas/publish-test
     handler: lambda_function.lambda_handler
   update-state:
@@ -253,6 +260,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/update-state/**
     module: lambdas/update-state
     handler: lambda_function.lambda_handler
   feed-rerun:
@@ -275,6 +285,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/feed-rerun/**
     module: lambdas/feed-rerun
     handler: lambda_function.lambda_handler
   feed-s3-inventory:
@@ -297,6 +310,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/feed-s3-inventory/**
     module: lambdas/feed-s3-inventory
     handler: lambda_function.lambda_handler
   feed-stac-api:
@@ -319,6 +335,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/feed-stac-api/**
     module: lambdas/feed-stac-api
     handler: lambda_function.lambda_handler
   feed-stac-crawl:
@@ -341,6 +360,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/feed-stac-crawl/**
     module: lambdas/feed-stac-crawl
     handler: lambda_function.lambda_handler
   add-preview:
@@ -368,6 +390,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/add-preview/**
     module: lambdas/add-preview
     handler: lambda_function.lambda_handler
   convert-to-cog:
@@ -395,6 +420,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/convert-to-cog/**
     module: lambdas/convert-to-cog
     handler: lambda_function.lambda_handler
   copy-assets:
@@ -417,6 +445,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/copy-assets/**
     module: lambdas/copy-assets
     handler: lambda_function.lambda_handler
   post-batch:
@@ -439,6 +470,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/post-batch/**
     module: lambdas/post-batch
     handler: lambda_function.lambda_handler
   pre-batch:
@@ -461,6 +495,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/pre-batch/**
     module: lambdas/pre-batch
     handler: lambda_function.lambda_handler
   publish:
@@ -484,6 +521,9 @@ functions:
       CIRRUS_PUBLISH_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-publish
       CIRRUS_FAILED_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
       CIRRUS_INVALID_TOPIC_ARN: arn:aws:sns:#{AWS::Region}:#{AWS::AccountId}:${self:service}-${self:provider.stage}-failed
+    package:
+      include:
+        - ./lambdas/publish/**
     module: lambdas/publish
     handler: lambda_function.lambda_handler
 stepFunctions:
@@ -1509,6 +1549,10 @@ resources:
     CirrusQueueSnsArn:
       Value:
         Ref: QueueTopic
+package:
+  individually: true
+  exclude:
+    - '**/*'
 plugins:
   - serverless-python-requirements
   - serverless-step-functions


### PR DESCRIPTION
I found a problem with the `add-preview` being unexpectedly large in a certain environment, and looking further into the lambda .zip files I found all lambdas were being packaged together. The dependencies remained unique to each lambda package, but all code and other ancillary files for all lambdas were in every .zip created.

This PR should resolve that problem and will hopefully make the .zips be consistently sized between machines.