### PR TITLE
74/workflow chaining

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pyyaml~=5.4
 click~=8.0
 rich~=10.6
 cfn-flip~=1.2
-cirrus-lib>=0.6.0a1
+cirrus-lib>=0.6.0a2

--- a/src/cirrus/builtins/functions/process/lambda_function.py
+++ b/src/cirrus/builtins/functions/process/lambda_function.py
@@ -53,6 +53,6 @@ def lambda_handler(payload, context):
 
     if len(catalogs) > 0:
         cats = Catalogs(catalogs)
-        cats.process()
+        cats()
 
     return len(catalogs)

--- a/src/cirrus/builtins/tasks/add-preview/lambda_function.py
+++ b/src/cirrus/builtins/tasks/add-preview/lambda_function.py
@@ -18,8 +18,8 @@ def lambda_handler(payload, context={}):
     logger = get_task_logger("task.add-preview", catalog=catalog)
 
     # get step configuration
-    config = catalog['process']['tasks'].get('add-preview', {})
-    outopts = catalog['process'].get('output_options', {})
+    config = catalog.get_task('add-preview', {})
+    outopts = catalog.process.get('output_options', {})
     assets = config.pop('assets', None)
     thumb = config.pop('thumbnail', False)
     config.pop('batch')

--- a/src/cirrus/builtins/tasks/convert-to-cog/lambda_function.py
+++ b/src/cirrus/builtins/tasks/convert-to-cog/lambda_function.py
@@ -19,8 +19,8 @@ def lambda_handler(payload, context={}):
     item = catalog['features'][0]  # collection=catalog['collections'][0])
 
     # configuration options
-    config = catalog['process']['tasks'].get('convert-to-cog', {})
-    outopts = catalog['process'].get('output_options', {})
+    config = catalog.get_task('convert-to-cog', {})
+    outopts = catalog.process.get('output_options', {})
     assets = config.get('assets')
 
     # create temporary work directory

--- a/src/cirrus/builtins/tasks/copy-assets/lambda_function.py
+++ b/src/cirrus/builtins/tasks/copy-assets/lambda_function.py
@@ -14,8 +14,8 @@ def lambda_handler(payload, context={}):
     item = catalog['features'][0]  # collection=catalog['collections'][0])
 
     # configuration options
-    config = catalog['process']['tasks'].get('copy-assets', {})
-    outopts = catalog['process'].get('output_options', {})
+    config = catalog.get_task('copy-assets', {})
+    outopts = catalog.process.get('output_options', {})
 
     # asset config
     assets = config.get('assets', item['assets'].keys())

--- a/src/cirrus/builtins/tasks/publish/lambda_function.py
+++ b/src/cirrus/builtins/tasks/publish/lambda_function.py
@@ -19,7 +19,7 @@ def lambda_handler(payload, context):
     catalog = Catalog.from_payload(payload)
     logger = get_task_logger("task.publish", catalog=catalog)
 
-    config = catalog['process']['tasks'].get('publish', {})
+    config = catalog.get_task('publish', {})
     public = config.get('public', False)
     # additional SNS topics to publish to
     topics = config.get('sns', [])
@@ -42,15 +42,15 @@ def lambda_handler(payload, context):
                 item['links'].append(link)
 
         # publish to s3
-        s3urls = catalog.publish_to_s3(DATA_BUCKET, public=public)
+        s3urls = catalog.publish_items_to_s3(DATA_BUCKET, public=public)
 
         # publish to Cirrus SNS publish topic
-        catalog.publish_to_sns()
+        catalog.publish_items_to_sns()
 
         # Deprecated additional topics
         if PUBLISH_TOPICS:
             for t in PUBLISH_TOPICS.split(','):
-                catalog.publish_to_sns(t)
+                catalog.publish_items_to_sns()
 
         for t in topics:
             catalog.publish_to_sns(t)

--- a/tests/fixture_data/build/hashes.json
+++ b/tests/fixture_data/build/hashes.json
@@ -52,8 +52,8 @@
         "size": 1136
     },
     "lambdas/copy-assets/lambda_function.py": {
-        "shasum": "741c90339b1bc5e2959674d7c0ea4977fa95385259b8f7ac304e149f0d40d2c3",
-        "size": 1820
+        "shasum": "228c783d5656c0f6ac5d64ad86214426fabfc6e092b97ff833abb6cd72c08603",
+        "size": 1802
     },
     "lambdas/feed-stac-api/requirements.txt": {
         "shasum": "1d1b8abaebb8da53b0ffa7cdcfdd90cdfd13b7d2430f52a5c25d8049149486fa",
@@ -88,8 +88,8 @@
         "size": 83
     },
     "lambdas/update-state/lambda_function.py": {
-        "shasum": "44abcd7e66c5925a18a75094462bd51a9d85c45dc419756a06e2d6336808b292",
-        "size": 5609
+        "shasum": "6bd07b3f15b6b638773f49908324141129c9a649cbf21d295c3fd5e5cc459e79",
+        "size": 6015
     },
     "lambdas/publish/requirements.txt": {
         "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
@@ -100,8 +100,8 @@
         "size": 826
     },
     "lambdas/publish/lambda_function.py": {
-        "shasum": "ebee03ebde30cab3db429bd257c2420fe17a6d9369a69c2ca923850cabc15604",
-        "size": 2084
+        "shasum": "b5bcd85cd81af48267b3970f3cfda2cfad17e6f95b224cba6d69fc4c74805e65",
+        "size": 2086
     },
     "lambdas/api/api.yaml": {
         "shasum": "d4fdab7e61372083de65e14be69e08416a7d1a26a76a0a578886ee8dea986385",
@@ -136,8 +136,8 @@
         "size": 1849
     },
     "lambdas/convert-to-cog/lambda_function.py": {
-        "shasum": "43d98f6a85a4e19440c056e2cefaa1f25f812da43182a85249a1ba3401d1d0d1",
-        "size": 4086
+        "shasum": "47250187d3961b325e6f1b62c0f14f65f770ca1dfa62e5e27507c3538503c4f4",
+        "size": 4068
     },
     "lambdas/process/requirements.txt": {
         "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
@@ -152,8 +152,8 @@
         "size": 3
     },
     "lambdas/process/lambda_function.py": {
-        "shasum": "6fee7bfe0619aa8c718826163c1108087bd209cdbbcf1037801defc189154ecd",
-        "size": 2181
+        "shasum": "ddffcc5b59d4ea80beb44b0c1207638b6caa4b29ce6e995dd713174a25e06060",
+        "size": 2173
     },
     "lambdas/add-preview/requirements.txt": {
         "shasum": "6dd3d02e12884ba0c5438d083ff498e8c49b8cd2faf06c8afcd6b47ba24a1e5e",
@@ -164,12 +164,12 @@
         "size": 1721
     },
     "lambdas/add-preview/lambda_function.py": {
-        "shasum": "cf40467d2a44f1ced91e13568a651a811de97a3df20c4f161f85785ea9c20163",
-        "size": 8492
+        "shasum": "4479a46da7b12e3d0c42b666d8ab419e263ed0a57cf72d0e5433a8546e585ab8",
+        "size": 8474
     },
     "cirrus/lib/catalog.py": {
-        "shasum": "e0ee1458b8d6b41863da694c15e3842c8ae4aaaf07dafcbfec8acb85daa1c720",
-        "size": 16165
+        "shasum": "bf41e6151f89174d02567129ff8dee5c63f8f7c01caf588a198e7ff7a85b6981",
+        "size": 17536
     },
     "cirrus/lib/logging.py": {
         "shasum": "bc3242afe713c5d4f4d4ce859b079c90caf3bdec4343a7d6d91026919f342819",


### PR DESCRIPTION
This is a sketch of the changes to implement workflow chaining. I based this branch on the branch of #69, which merges in cirrus-lib, so that I could make all the required changes in one place. If it turns out we are not good with #69 I can port the cirrus-lib changes into the cirrus-lib repo.

I plan to work on some tests to validate the behavior will work as intended, but essentially it should allow:
* a process block array, so we can chain workflows together, each with a specific process definition
* a nested array within that to allow parallel workflow fan-out, where workflow outputs branch

The intent of all this is to allow a process block that looks roughly like this:
```
...
    process = {[
        { workflow 1 },
        [{ workflow 2a }, { workflow 2b }],
        { workflow 3 }
    ]}
...
```

This would run like :
```
    workflow 1  --+-->  workflow 2a  ---->  workflow 3
                  |
                  +-->  workflow 2b  ---->  workflow 3
```

Currently the fan-out happens in the `update-state` step after a workflow has finished, though I believe I should move it into the `process` lambda handling of input payloads, to support fan-outs for the first workflow process definition.

A future improvement will be designing some mechanism to wait for parallel outputs required for a later workflow step, which would allow us to model a chain like:
```
    workflow 1  --+-->  workflow 2a  ---->  workflow 3  --+
                  |                                       +-->  workflow 4
                  +-->  workflow 2b  ---->  workflow 3  --+
```

But that's out of scope at the moment.