### PR TITLE
post-batch cleanup and fixes re 75

### DIFF
--- a/cirrus/cli/components/tasks/config/post-batch/lambda_function.py
+++ b/cirrus/cli/components/tasks/config/post-batch/lambda_function.py
@@ -1,36 +1,41 @@
-import boto3
+import re
 import json
+
+import boto3
+
 from cirruslib import Catalog
 
 
 LOG_CLIENT = boto3.client('logs')
-
-
-class BaseException(Exception):
-    pass
+DEFAULT_ERROR = 'UnknownError'
 
 
 def lambda_handler(payload, context):
-    if 'error' in payload:
-        error = payload.get('error', {})
-        cause = json.loads(error['Cause'])
-        logname = cause['Attempts'][-1]['Container']['LogStreamName']
+    if 'error' not in payload:
+        catalog = Catalog.from_payload(payload)
+        return catalog
+
+    error = payload.get('error', {})
+    cause = json.loads(error['Cause'])
+    logname = cause['Attempts'][-1]['Container']['LogStreamName']
+
+    try:
         error_type, error_msg = get_error_from_batch(logname)
-        exception_class = type(error_type, (BaseException, Exception), {})
-        raise exception_class(error_msg)
-    catalog = Catalog.from_payload(payload)
-    return catalog
+    except Exception as e:
+        raise Exception("Unable to get error log") from e
+
+    exception_class = type(error_type, (Exception,), {})
+    raise exception_class(error_msg)
 
 
 def get_error_from_batch(logname):
-    try:
-        logs = LOG_CLIENT.get_log_events(logGroupName='/aws/batch/job', logStreamName=logname)
-        msg = logs['events'][-1]['message'].lstrip('cirruslib.errors.')
-        parts = msg.split(':', maxsplit=1)
-        if len(parts) > 1:
-            error_type = parts[0]
-            msg = parts[1]
-            return error_type, msg
-        return "Unknown", msg
-    except Exception:
-        return "Exception", "Unable to get Error Log"
+    logs = LOG_CLIENT.get_log_events(
+        logGroupName='/aws/batch/job',
+        logStreamName=logname,
+    )
+    msg = logs['events'][-1]['message'].removeprefix('cirruslib.errors.')
+
+    error_regex = re.compile(r'(^[\.\w]+:)?\s*(.*)')
+    error_type, msg = error_regex.match(msg).groups()
+
+    return error_type or DEFAULT_ERROR, msg


### PR DESCRIPTION
* Ensures exceptions within post-batch are logged
* No longer drops chars at beginning of error messages:
  * Uses `removeprefix` as intended, instead of `lstrip`
* More robust error class determination:
  * Now matches on whole word at start of message text ending with colon
  * Still susceptiable to messages like `Error:.*`
* Other cleanup