### PR TITLE
build tests store less state and cirrus-lib from python env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ node_modules/
 .serverless
 .dist/
 dist/
-build/
+/build/
 .env
 packages/
 *.egg-info/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pyyaml~=5.4
 click~=8.0
 rich~=10.6
 cfn-flip~=1.2
-cirrus-lib>=0.5.1
+cirrus-lib>=0.6.0a1

--- a/src/cirrus/builtins/feeders/feed-rerun/lambda_function.py
+++ b/src/cirrus/builtins/feeders/feed-rerun/lambda_function.py
@@ -4,8 +4,8 @@ import json
 import logging
 import sys
 
-from cirruslib.statedb import StateDB
-from cirruslib.utils import submit_batch_job
+from cirrus.lib.statedb import StateDB
+from cirrus.lib.utils import submit_batch_job
 from os import getenv
 
 

--- a/src/cirrus/builtins/feeders/feed-s3-inventory/lambda_function.py
+++ b/src/cirrus/builtins/feeders/feed-s3-inventory/lambda_function.py
@@ -12,7 +12,7 @@ from os import getenv, path as op
 
 import pyorc
 from boto3utils import s3
-from cirruslib.utils import submit_batch_job
+from cirrus.lib.utils import submit_batch_job
 
 
 # envvars

--- a/src/cirrus/builtins/feeders/feed-stac-api/definition.yml
+++ b/src/cirrus/builtins/feeders/feed-stac-api/definition.yml
@@ -2,6 +2,7 @@ description: Feed data from a STAC API to Cirrus for processing
 lambda:
   memorySize: 128
   timeout: 900
-python_requirements:
-  #- sat-search~=0.3.0
-  - python-dateutil~=2.8
+  pythonRequirements:
+    include:
+      #- sat-search~=0.3.0
+      - python-dateutil~=2.8

--- a/src/cirrus/builtins/feeders/feed-stac-api/lambda_function.py
+++ b/src/cirrus/builtins/feeders/feed-stac-api/lambda_function.py
@@ -10,7 +10,7 @@ import time
 from copy import deepcopy
 from dateutil.parser import parse
 
-from cirruslib.utils import submit_batch_job
+from cirrus.lib.utils import submit_batch_job
 from satsearch import Search
 
 

--- a/src/cirrus/builtins/feeders/feed-stac-crawl/lambda_function.py
+++ b/src/cirrus/builtins/feeders/feed-stac-crawl/lambda_function.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-from cirruslib.utils import submit_batch_job
+from cirrus.lib.utils import submit_batch_job
 from pystac import Catalog
 
 # envvars

--- a/src/cirrus/builtins/functions/api/lambda_function.py
+++ b/src/cirrus/builtins/functions/api/lambda_function.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from urllib.parse import urljoin
 
 from boto3utils import s3
-from cirruslib import StateDB, STATES
+from cirrus.lib.statedb import StateDB, STATES
 
 logger = logging.getLogger(__name__)
 

--- a/src/cirrus/builtins/functions/process/lambda_function.py
+++ b/src/cirrus/builtins/functions/process/lambda_function.py
@@ -1,10 +1,9 @@
 import json
 import os
 
-from cirruslib import Catalog, Catalogs
-from cirruslib.utils import dict_merge
-from cirruslib.logging import get_task_logger
-
+from cirrus.lib.catalog import Catalog, Catalogs
+from cirrus.lib.utils import dict_merge
+from cirrus.lib.logging import get_task_logger
 
 logger = get_task_logger('lambda_function.process', catalog=tuple())
 

--- a/src/cirrus/builtins/functions/update-state/lambda_function.py
+++ b/src/cirrus/builtins/functions/update-state/lambda_function.py
@@ -4,8 +4,9 @@ import boto3
 
 from os import getenv
 
-from cirruslib import Catalog, StateDB
-from cirruslib.logging import get_task_logger
+from cirrus.lib.catalog import Catalog
+from cirrus.lib.statedb import StateDB
+from cirrus.lib.logging import get_task_logger
 
 
 logger = get_task_logger('lambda_function.update-state', catalog=tuple())
@@ -135,7 +136,8 @@ def get_execution_error(arn):
     return error
 
 
-# TODO: in cirruslib make a factory class that returns classes
+
+# TODO: in cirrus.lib make a factory class that returns classes
 # for each error type, and generalize the processing here into
 # a well-known type interface
 def parse_payload(payload):

--- a/src/cirrus/builtins/tasks/add-preview/definition.yml
+++ b/src/cirrus/builtins/tasks/add-preview/definition.yml
@@ -2,12 +2,13 @@ description: Create a preview and/or thumbnail from one or more assets
 environment:
   GDAL_DATA: /opt/share/gdal
   PROJ_LIB: /opt/share/proj
-python_requirements:
-  - rasterio==1.2.8
-  - rio-cogeo~=1.1.10
 lambda:
   memorySize: 1024
   timeout: 900
   layers:
     - arn:aws:lambda:${self:provider.region}:552188055668:layer:geolambda:2
     - arn:aws:lambda:${self:provider.region}:552188055668:layer:geolambda-python:1
+  pythonRequirements:
+    include:
+      - rasterio==1.2.8
+      - rio-cogeo~=1.1.10

--- a/src/cirrus/builtins/tasks/add-preview/lambda_function.py
+++ b/src/cirrus/builtins/tasks/add-preview/lambda_function.py
@@ -5,8 +5,9 @@ import tempfile
 
 import gdal
 import rasterio
-from cirruslib import Catalog, get_task_logger
-from cirruslib.transfer import download_item_assets, upload_item_assets
+from cirrus.lib.catalog import Catalog
+from cirrus.lib.logging import get_task_logger
+from cirrus.lib.transfer import download_item_assets, upload_item_assets
 from rio_cogeo.cogeo import cog_translate
 from rio_cogeo.profiles import cog_profiles
 from rasterio.warp import calculate_default_transform, reproject as _reproject, Resampling

--- a/src/cirrus/builtins/tasks/convert-to-cog/definition.yml
+++ b/src/cirrus/builtins/tasks/convert-to-cog/definition.yml
@@ -8,6 +8,7 @@ lambda:
   layers:
     - arn:aws:lambda:${self:provider.region}:552188055668:layer:geolambda:2
     - arn:aws:lambda:${self:provider.region}:552188055668:layer:geolambda-python:1
-python_requirements:
-  - rasterio==1.2.8
-  - rio-cogeo~=1.1.10
+  pythonRequirements:
+    include:
+      - rasterio==1.2.8
+      - rio-cogeo~=1.1.10

--- a/src/cirrus/builtins/tasks/convert-to-cog/lambda_function.py
+++ b/src/cirrus/builtins/tasks/convert-to-cog/lambda_function.py
@@ -3,9 +3,9 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 import rasterio
-from cirruslib import Catalog, get_task_logger
-from cirruslib.errors import InvalidInput
-from cirruslib.transfer import download_item_assets, upload_item_assets, s3_sessions
+from cirrus.lib import Catalog, get_task_logger
+from cirrus.lib.errors import InvalidInput
+from cirrus.lib.transfer import download_item_assets, upload_item_assets, s3_sessions
 from rasterio.errors import CRSError
 from rio_cogeo.cogeo import cog_translate
 from rio_cogeo.profiles import cog_profiles

--- a/src/cirrus/builtins/tasks/copy-assets/lambda_function.py
+++ b/src/cirrus/builtins/tasks/copy-assets/lambda_function.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-from cirruslib import Catalog, get_task_logger
-from cirruslib.transfer import download_item_assets, upload_item_assets
+from cirrus.lib import Catalog, get_task_logger
+from cirrus.lib.transfer import download_item_assets, upload_item_assets
 from shutil import rmtree
 from tempfile import mkdtemp
 

--- a/src/cirrus/builtins/tasks/pre-batch/lambda_function.py
+++ b/src/cirrus/builtins/tasks/pre-batch/lambda_function.py
@@ -2,7 +2,8 @@ import uuid
 from os import getenv
 
 from boto3utils import s3
-from cirruslib import Catalog, get_task_logger
+from cirrus.lib.catalog import Catalog
+from cirrus.lib.logging import get_task_logger
 
 # envvars
 CATALOG_BUCKET = getenv('CIRRUS_CATALOG_BUCKET')

--- a/src/cirrus/builtins/tasks/publish/lambda_function.py
+++ b/src/cirrus/builtins/tasks/publish/lambda_function.py
@@ -1,7 +1,9 @@
 import json
 from os import getenv
 
-from cirruslib import Catalog, StateDB, get_task_logger
+from cirrus.lib.catalog import Catalog
+from cirrus.lib.statedb import StateDB
+from cirrus.lib.logging import get_task_logger
 
 # envvars
 DATA_BUCKET = getenv('CIRRUS_DATA_BUCKET')

--- a/src/cirrus/core/components/base/_lambda.py
+++ b/src/cirrus/core/components/base/_lambda.py
@@ -1,8 +1,8 @@
 import logging
 import click
 import textwrap
+import copy
 
-from typing import List
 from pathlib import Path
 
 from .. import files
@@ -25,7 +25,6 @@ class Lambda(Component):
         # simpler if we know we are batch disabled for all Lambdas
         self.batch_enabled = False
         self.description = self.config.get('description', '')
-        self.python_requirements = self.config.pop('python_requirements', [])
 
         self.lambda_config = self.config.get('lambda', NamedYamlable())
         self.lambda_enabled = self.lambda_config.pop('enabled', True) and self._enabled and bool(self.lambda_config)
@@ -38,6 +37,14 @@ class Lambda(Component):
         self.lambda_config.package = {}
         self.lambda_config.package.include = []
         self.lambda_config.package.include.append(f'./lambdas/{self.name}/**')
+
+        if not hasattr(self.lambda_config, 'pythonRequirements'):
+            self.lambda_config.pythonRequirements = {}
+        self.lambda_config.pythonRequirements['include'] = sorted(list({
+            req for req in
+            self.lambda_config.pythonRequirements.get('include', [])
+            + list(self.project.config.custom.pythonRequirements.include)
+        }))
 
         if not hasattr(self.lambda_config, 'module'):
             self.lambda_config.module = f'lambdas/{self.name}'
@@ -61,10 +68,17 @@ class Lambda(Component):
         click.echo('Lambda config:')
         click.echo(textwrap.indent(self.lambda_config.to_yaml(), '  '))
 
+    def copy_for_config(self):
+        lc = copy.deepcopy(self.lambda_config)
+        lc.pop('pythonRequirements', None)
+        return lc
+
     def get_outdir(self, project_build_dir: Path) -> Path:
         return project_build_dir.joinpath(self.lambda_config.module)
 
-    def link_to_outdir(self, outdir: Path, project_python_requirements: List[str]) -> None:
+    def link_to_outdir(self, outdir: Path) -> None:
+        import shutil
+
         try:
             outdir.mkdir(parents=True)
         except FileExistsError:
@@ -77,11 +91,16 @@ class Lambda(Component):
             # TODO: could have a problem on windows
             # if lambda has a directory in it
             # probably affects handler default too
-            outdir.joinpath(_file.name).symlink_to(_file)
+            if _file.is_dir():
+                shutil.copytree(_file, outdir.joinpath(_file.name))
+            else:
+                shutil.copyfile(_file, outdir.joinpath(_file.name))
 
-        reqs = self.python_requirements + project_python_requirements
         outdir.joinpath('requirements.txt').write_text(
-            '\n'.join(reqs),
+            ''.join(
+                [f'{req}\n' for req in
+                 self.lambda_config.pythonRequirements.get('include', [])],
+            ),
         )
 
     def clean_outdir(self, outdir: Path):

--- a/src/cirrus/core/components/base/step_function.py
+++ b/src/cirrus/core/components/base/step_function.py
@@ -2,7 +2,6 @@ import logging
 
 from .. import files
 from .component import Component
-from cirrus.core.utils.yaml import NamedYamlable
 
 
 logger = logging.getLogger(__name__)

--- a/src/cirrus/core/components/files/definitions.py
+++ b/src/cirrus/core/components/files/definitions.py
@@ -9,13 +9,14 @@ logger = logging.getLogger(__name__)
 # TODO: figure out most basic permissions
 lambda_base = '''description: {description}
 iamRoleStatements: []
-python_requirements: []
 environment: {{}}
 '''.format
 
 lambda_lambda = '''lambda:
   memorySize: 128
   timeout: 60
+  pythonRequirements:
+    include: []
 '''.format
 
 lambda_batch = '''batch:

--- a/src/cirrus/core/components/files/handlers.py
+++ b/src/cirrus/core/components/files/handlers.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 
 default_handler = '''#!/usr/bin/env python
-from cirruslib import Catalog, get_task_logger
+from cirrus.lib.catalog import Catalog
+from cirrus.lib.logging import get_task_logger
 
 
 LAMBDA_TYPE = '{component_type}'

--- a/src/cirrus/core/config/__init__.py
+++ b/src/cirrus/core/config/__init__.py
@@ -113,6 +113,12 @@ class Config(NamedYamlable):
             self.register_step_function(sf_component)
 
     def register_step_function(self, sf_component) -> None:
+        if not sf_component.enabled:
+            logging.debug(
+                "Skipping disabled step function: '%s'",
+                sf_component.display_name,
+            )
+            return
         if sf_component.name in self.stepFunctions.stateMachines and not sf_component.is_core_component:
             logging.warning(
                 f"Duplicate step function declaration '{sf_component.display_name}', skipping",

--- a/src/cirrus/core/utils/misc.py
+++ b/src/cirrus/core/utils/misc.py
@@ -10,10 +10,15 @@ def get_cirrus_lib_requirements() -> List[str]:
     '''
     try:
         from importlib import metadata
+        print("using importlib")
     except ImportError:
         import importlib_metadata as metadata
+        print("using importlib_metadata")
 
-    return [req.split(';')[0] for req in metadata.requires('cirrus-lib')]
+    return [
+        req.split(';')[0].translate(str.maketrans('','',' ()'))
+        for req in metadata.requires('cirrus-lib')
+    ]
 
 
 def relative_to(path1: Path, path2: Path) -> Path:

--- a/src/cirrus/core/utils/misc.py
+++ b/src/cirrus/core/utils/misc.py
@@ -1,27 +1,25 @@
 import os
+
+from typing import List
 from pathlib import Path
 
 
-def get_cirrus_lib_requirement() -> str:
+def get_cirrus_lib_requirements() -> List[str]:
     '''
-    Get the cirrus-lib dependency specified for this package.
+    Get the cirrus-lib dependencies.
     '''
     try:
         from importlib import metadata
     except ImportError:
         import importlib_metadata as metadata
 
-    package_name = 'cirrus-geo'
-    return [
-        req for req in metadata.requires(package_name)
-        if req.startswith('cirrus-lib')
-    ][0]
+    return [req.split(';')[0] for req in metadata.requires('cirrus-lib')]
 
 
-def relative_to_cwd(path: Path) -> Path:
-    common_path = Path(os.getcwd())
+def relative_to(path1: Path, path2: Path) -> Path:
+    common_path = path1
     relative = ''
-    path = path.resolve()
+    path = path2.resolve()
     result = path
 
     while True:
@@ -41,3 +39,7 @@ def relative_to_cwd(path: Path) -> Path:
         common_path = _common_path
 
     return result
+
+
+def relative_to_cwd(path: Path) -> Path:
+    return relative_to(Path(os.getcwd()), path)

--- a/tests/fixture_data/build/hashes.json
+++ b/tests/fixture_data/build/hashes.json
@@ -1,11 +1,11 @@
 {
     "serverless.yml": {
-        "shasum": "49f5377e6a8338a1a7c24d3ef10ff58eaa58e40d39fe9b5763923525d6dfdf25",
-        "size": 58073
+        "shasum": "3a8a51dc514432e09e19716ad732d0b76904711f5634cd2ae23cfb286789c8d5",
+        "size": 59033
     },
     "lambdas/publish-test/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/publish-test/README.md": {
         "shasum": "0e8dc25d1241c9d02eabf0bebf7851606dc161f2834c97e2b5ecc8ff232dc8cc",
@@ -16,132 +16,132 @@
         "size": 590
     },
     "lambdas/feed-stac-crawl/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/feed-stac-crawl/README.md": {
         "shasum": "9ce852981298e80c8859be361a11a6847cc571541a39762133416deb40ce7a76",
         "size": 70
     },
     "lambdas/feed-stac-crawl/lambda_function.py": {
-        "shasum": "a49bcd94fceca09e334e2666ad4f0fba554254e33e3c9e2ac3370e9f722e6ece",
-        "size": 1429
+        "shasum": "7e2d6254b1ef7f4c3defc73ca398499a4e98ec7156c54b1424a3b3d3442f5c3f",
+        "size": 1430
     },
     "lambdas/pre-batch/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/pre-batch/lambda_function.py": {
-        "shasum": "1210d153ddc9ce97eadcdf3d340bfe4630865743fb401876472e99b8cf069964",
-        "size": 754
+        "shasum": "e5db940f7cb2d2c057d8d82ea43ef29b04f14f7c6e3fcb2c59946375d3146f62",
+        "size": 793
     },
     "lambdas/post-batch/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/post-batch/lambda_function.py": {
         "shasum": "81183a231e7d42a76d5938326f411b1b6a5f728001572af751268da9514742e8",
         "size": 1428
     },
     "lambdas/copy-assets/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/copy-assets/README.md": {
         "shasum": "7f2fb18a17278d9aa76b70410b9ac27fb0c311f338b5c9fed847ea2d1b0dde26",
         "size": 1136
     },
     "lambdas/copy-assets/lambda_function.py": {
-        "shasum": "9cbef37e3456e11715cc3c27db45c5551517da81c98b9e0b8cd8346d2cad7533",
-        "size": 1818
+        "shasum": "741c90339b1bc5e2959674d7c0ea4977fa95385259b8f7ac304e149f0d40d2c3",
+        "size": 1820
     },
     "lambdas/feed-stac-api/requirements.txt": {
-        "shasum": "b976b7ba598c55fbcf8687727f1db07e3c9ae139b9609d7efd32d361629c3f18",
-        "size": 38
+        "shasum": "1d1b8abaebb8da53b0ffa7cdcfdd90cdfd13b7d2430f52a5c25d8049149486fa",
+        "size": 81
     },
     "lambdas/feed-stac-api/README.md": {
         "shasum": "a5107a831d1dbae3ae6d00adf0412b79e67edcf2630ccf70e58fdb1817983626",
         "size": 269
     },
     "lambdas/feed-stac-api/lambda_function.py": {
-        "shasum": "0c8729bd630429d4b1967718e64b512b093d18fc33ed9dd8b4b956d48740cf72",
-        "size": 4280
+        "shasum": "4e6e5d869e54419a2c12c761db8642c88fca299a3b42be8818d1719006bd2f8b",
+        "size": 4281
     },
     "lambdas/feed-s3-inventory/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/feed-s3-inventory/README.md": {
         "shasum": "ef297e110da57ba9500090c45a87398dc7c5fc95db111046a09300c791a809b8",
         "size": 987
     },
     "lambdas/feed-s3-inventory/lambda_function.py": {
-        "shasum": "4512f5cbbb0f014848940ada57c3351456a1c08671d34ef416eb3fd69ff5c768",
-        "size": 7745
+        "shasum": "1faabae202bd0b0d970da7c73210264b4bbd408f26ff114330a4ae6ad118e158",
+        "size": 7746
     },
     "lambdas/update-state/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/update-state/README.md": {
         "shasum": "c747c571fc2fdef80b4520b8f85b7edd93b92f3b0fa292410f326fcbfbcc9d6a",
         "size": 83
     },
     "lambdas/update-state/lambda_function.py": {
-        "shasum": "fc90fbbf260807d94799ee533cf0e882128bd15d4e4188ba531bbf2c6ac094d8",
-        "size": 5567
+        "shasum": "44abcd7e66c5925a18a75094462bd51a9d85c45dc419756a06e2d6336808b292",
+        "size": 5609
     },
     "lambdas/publish/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/publish/README.md": {
         "shasum": "df46c55ffe39c090c2790c4e47ff8bd6bea814c796cf4f6479e97afa25b4f0e7",
         "size": 826
     },
     "lambdas/publish/lambda_function.py": {
-        "shasum": "50bca5e60195be1f48f07582e734656e24c462d27717472036205d9fd756ee21",
-        "size": 2015
+        "shasum": "ebee03ebde30cab3db429bd257c2420fe17a6d9369a69c2ca923850cabc15604",
+        "size": 2084
     },
     "lambdas/api/api.yaml": {
         "shasum": "d4fdab7e61372083de65e14be69e08416a7d1a26a76a0a578886ee8dea986385",
         "size": 1403
     },
     "lambdas/api/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/api/lambda_function.py": {
-        "shasum": "7acb40a11d27f6e2f6af9bb002cde8197d249d1f496375eeedf91567849c0ace",
-        "size": 5394
+        "shasum": "4970a4e704be0e82486074b1432539f08ce85209ffbb83d61db9a25d7ecde41a",
+        "size": 5403
     },
     "lambdas/feed-rerun/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/feed-rerun/README.md": {
         "shasum": "7e7ec9226f9d7eb4609f89dc9b46ffe92cffd5a7490ca6f8c77d9a3fce753813",
         "size": 945
     },
     "lambdas/feed-rerun/lambda_function.py": {
-        "shasum": "853bbe9763dd35dc039da33b3df5823829ad9520c991a116673f2707345fd5f1",
-        "size": 2214
+        "shasum": "6acd47d710e205a0496addb86b48e56304a06aca156b003994cdf6ab8b91963e",
+        "size": 2216
     },
     "lambdas/convert-to-cog/requirements.txt": {
-        "shasum": "833362cb5a918ce5e5978384b54715ff035948b2905647d579695ac183e5ae94",
-        "size": 51
+        "shasum": "6dd3d02e12884ba0c5438d083ff498e8c49b8cd2faf06c8afcd6b47ba24a1e5e",
+        "size": 94
     },
     "lambdas/convert-to-cog/README.md": {
         "shasum": "1c63d41de084e813acfc6f3214367196eef567dbf636b3eb82b9d78f9f53dde3",
         "size": 1849
     },
     "lambdas/convert-to-cog/lambda_function.py": {
-        "shasum": "ed0a5c38f22f7cc3a109644a3c6127a7421f498c4150d893b222b002ebf41400",
-        "size": 4083
+        "shasum": "43d98f6a85a4e19440c056e2cefaa1f25f812da43182a85249a1ba3401d1d0d1",
+        "size": 4086
     },
     "lambdas/process/requirements.txt": {
-        "shasum": "3a40ff0505f0a437892ae102f688b1c2ef7d572dd6eefd89c05941a001d738a4",
-        "size": 17
+        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
+        "size": 60
     },
     "lambdas/process/README.md": {
         "shasum": "396db431f2d8638f21094af3270b680c48276728d19416c759450018d7505844",
@@ -152,19 +152,47 @@
         "size": 3
     },
     "lambdas/process/lambda_function.py": {
-        "shasum": "01f7de534bcedbbc48c580d53faf24de72002675b3b7318b38e544255b3fcf42",
-        "size": 2171
+        "shasum": "6fee7bfe0619aa8c718826163c1108087bd209cdbbcf1037801defc189154ecd",
+        "size": 2181
     },
     "lambdas/add-preview/requirements.txt": {
-        "shasum": "833362cb5a918ce5e5978384b54715ff035948b2905647d579695ac183e5ae94",
-        "size": 51
+        "shasum": "6dd3d02e12884ba0c5438d083ff498e8c49b8cd2faf06c8afcd6b47ba24a1e5e",
+        "size": 94
     },
     "lambdas/add-preview/README.md": {
         "shasum": "a3b594f6f897742d38e6566f8be6cfe3c195fd4ed33077c7f3316f573b2345fe",
         "size": 1721
     },
     "lambdas/add-preview/lambda_function.py": {
-        "shasum": "d77d6b0bef45877a9a74da02a8b8035cfe6500407dbf5361e5c65f763a5b8b77",
-        "size": 8452
+        "shasum": "cf40467d2a44f1ced91e13568a651a811de97a3df20c4f161f85785ea9c20163",
+        "size": 8492
+    },
+    "cirrus/lib/catalog.py": {
+        "shasum": "e0ee1458b8d6b41863da694c15e3842c8ae4aaaf07dafcbfec8acb85daa1c720",
+        "size": 16165
+    },
+    "cirrus/lib/logging.py": {
+        "shasum": "bc3242afe713c5d4f4d4ce859b079c90caf3bdec4343a7d6d91026919f342819",
+        "size": 1849
+    },
+    "cirrus/lib/__init__.py": {
+        "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 0
+    },
+    "cirrus/lib/transfer.py": {
+        "shasum": "b1ea435e9a2691d1f99d61948568b57806d0da46e24640a064c86aeccc5076e5",
+        "size": 6401
+    },
+    "cirrus/lib/utils.py": {
+        "shasum": "4cb609767b4660b98429d1c88bd15905f3720fc0f2c7478899bbd7ceb87108da",
+        "size": 3815
+    },
+    "cirrus/lib/errors.py": {
+        "shasum": "15c62d1e8015f09103937c5f400a9814c2d8c2cf01844e0c8e1fcbc49c473e9b",
+        "size": 173
+    },
+    "cirrus/lib/statedb.py": {
+        "shasum": "c9114c54404f2b9b83485ea950d983acc17ebfe695e67099d6ce16d2de3e7a15",
+        "size": 18053
     }
 }

--- a/tests/fixture_data/build/serverless.yml
+++ b/tests/fixture_data/build/serverless.yml
@@ -149,13 +149,13 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: &id001
+      CIRRUS_BUCKET:
         Ref: ServerlessDeploymentBucket
-      CIRRUS_DATA_BUCKET: &id002
+      CIRRUS_DATA_BUCKET:
         Ref: Data
-      CIRRUS_CATALOG_BUCKET: &id003
+      CIRRUS_CATALOG_BUCKET:
         Ref: Catalogs
-      CIRRUS_STATE_DB: &id004
+      CIRRUS_STATE_DB:
         Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
@@ -184,10 +184,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -211,10 +215,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -256,10 +264,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -281,10 +293,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -306,10 +322,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -331,10 +351,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -356,10 +380,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -386,10 +414,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -416,10 +448,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -441,10 +477,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -466,10 +506,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -491,10 +535,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process
@@ -517,10 +565,14 @@ functions:
       CIRRUS_PUBLIC_CATALOG: false
       CIRRUS_STAC_VERSION: 1.0.0-beta.2
       CIRRUS_LOG_LEVEL: DEBUG
-      CIRRUS_BUCKET: *id001
-      CIRRUS_DATA_BUCKET: *id002
-      CIRRUS_CATALOG_BUCKET: *id003
-      CIRRUS_STATE_DB: *id004
+      CIRRUS_BUCKET:
+        Ref: ServerlessDeploymentBucket
+      CIRRUS_DATA_BUCKET:
+        Ref: Data
+      CIRRUS_CATALOG_BUCKET:
+        Ref: Catalogs
+      CIRRUS_STATE_DB:
+        Ref: StateTable
       CIRRUS_STACK: ${self:service}-${self:provider.stage}
       BASE_WORKFLOW_ARN: arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-
       CIRRUS_PROCESS_QUEUE: ${self:service}-${self:provider.stage}-process

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,6 +115,9 @@ def test_build(invoke, project, reference_build, build_dir):
         print(f'Files in missing from build: {missing}')
         print(f'Files added in build: {added}')
         print(f'Files different in build: {changed}')
+        for f in changed:
+            print(f"Content of '{f}':")
+            print(build_dir.joinpath(f).read_text())
 
         if 'serverless.yml' in changed:
             with reference_build.joinpath('serverless.yml').open() as f1:


### PR DESCRIPTION
This PR encapsulates two sets of changes:
* rather than storing every file put into the build, we now just track changes to serverless.yml with a diff, and all other files simply by added/changed/removed (using shasum/size for change detection)
* rather than using python-serverless-requirements to pull cirrus-lib from pypi, we instead copy cirrus-lib from the local python env, and build that into the lambda packages.

The testing changes help with the cirrus-lib change by reducing the fixture diff (though all the fixture deletions are still part of this review, sorry). The cirrus-lib change closes #66 by _not_ merging cirrus lib but using the lessons learned from an attempt at doing so, and addresses #55 by better addressing how cirrus-lib is packaged and `pythonRequirements` are managed.

Note that in lambda `definition.yml` files, the `python_requirements` keyword has been renamed to `pythonRequirements` for consistency, and also moved under the `lambda` section. This is a non-backwards compatible change.

Lastly, note that this PR is dependent on the cirrus-lib changes in cirrus-geo/cirrus-lib#31. Until those changes are merged and a release is cut on that side, the CI tests will fail. At the time of a release there we will want to update the requirements.txt for this project as well, to ensure we are using that new release as the minimal version.