### PR TITLE
fix showing yaml fn args re #98

### DIFF
--- a/src/cirrus/core/components/files/base.py
+++ b/src/cirrus/core/components/files/base.py
@@ -86,4 +86,4 @@ class ComponentFile:
         path.write_text(self.content_fn(parent_component))
 
     def show(self):
-        self.console.print(self.content)
+        self.console.print_escaped(self.content)

--- a/src/cirrus/core/utils/console.py
+++ b/src/cirrus/core/utils/console.py
@@ -1,2 +1,12 @@
 from rich.console import Console
+from rich.markup import escape
+
+
 console = Console()
+
+
+def print_escaped(self, *args, **kwargs):
+    self.print(escape(*args, **kwargs))
+
+
+console.print_escaped = print_escaped.__get__(console)


### PR DESCRIPTION
Ensures the content is escaped before printing to the terminal to preserve function args in `[]`. See https://rich.readthedocs.io/en/stable/markup.html#escaping for the rich documentation on the subject. Closes #98.