### PR TITLE
Chaining item filter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and then replace all custom `cirrus.yml` content that is still required.
 
 - README badges and codecov support ([#88])
 - workflow chaining support ([#74])
+- item filter support for workflow chaining ([#99])
 - CloudFormation support for all types beyond Resources and Outputs ([#64])
 - `AWS_REGION` and `AWS_DEFAULT_REGION` env vars injected into batch job
   definitions by default ([44bebc5])
@@ -290,6 +291,7 @@ Initial release
 [#79]: https://github.com/cirrus-geo/cirrus-geo/issues/79
 [#82]: https://github.com/cirrus-geo/cirrus-geo/issues/82
 [#98]: https://github.com/cirrus-geo/cirrus-geo/issues/98
+[#99]: https://github.com/cirrus-geo/cirrus-geo/issues/99
 
 [#71]: https://github.com/cirrus-geo/cirrus-geo/pull/72
 [#72]: https://github.com/cirrus-geo/cirrus-geo/pull/72

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pyyaml~=5.4
 click~=8.0
 rich~=10.6
 cfn-flip~=1.2
-cirrus-lib~=0.6.0
+cirrus-lib~=0.6.1

--- a/src/cirrus/core/utils/json_compare.py
+++ b/src/cirrus/core/utils/json_compare.py
@@ -1,27 +1,6 @@
-def recursive_compare(d1, d2, level='root'):
-    if isinstance(d1, dict) and isinstance(d2, dict):
-        if d1.keys() != d2.keys():
-            s1 = set(d1.keys())
-            s2 = set(d2.keys())
-            print('{:<20} + {} - {}'.format(level, s1-s2, s2-s1))
-            common_keys = s1 & s2
-        else:
-            common_keys = set(d1.keys())
+import sys
 
-        for k in common_keys:
-            recursive_compare(d1[k], d2[k], level='{}.{}'.format(level, k))
-
-    elif isinstance(d1, list) and isinstance(d2, list):
-        if len(d1) != len(d2):
-            print('{:<20} len1={}; len2={}'.format(level, len(d1), len(d2)))
-        common_len = min(len(d1), len(d2))
-
-        for i in range(common_len):
-            recursive_compare(d1[i], d2[i], level='{}[{}]'.format(level, i))
-
-    else:
-        if d1 != d2:
-            print('{:<20} {} != {}'.format(level, d1, d2))
+from cirrus.lib import utils
 
 
 def parse_args(args=None):
@@ -45,4 +24,4 @@ if __name__ == '__main__':
     d1 = load_json(args.json1_file)
     d2 = load_json(args.json2_file)
 
-    recursive_compare(d1, d2)
+    sys.exit(not utils.recursive_compare(d1, d2))

--- a/tests/fixture_data/build/hashes.json
+++ b/tests/fixture_data/build/hashes.json
@@ -4,8 +4,8 @@
         "size": 59388
     },
     "lambdas/feed-stac-crawl/requirements.txt": {
-        "shasum": "9451888a9b4f254b8a8e033a7f6e65e30c812ffa3ea2f3e22f1142478e114ccb",
-        "size": 74
+        "shasum": "fd987d18dd2ae211b1a4d9b92ab263d66d65a0231b548cde8976b87ea3380d2e",
+        "size": 93
     },
     "lambdas/feed-stac-crawl/README.md": {
         "shasum": "9ce852981298e80c8859be361a11a6847cc571541a39762133416deb40ce7a76",
@@ -16,24 +16,24 @@
         "size": 1432
     },
     "lambdas/pre-batch/requirements.txt": {
-        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
-        "size": 60
+        "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
+        "size": 79
     },
     "lambdas/pre-batch/lambda_function.py": {
         "shasum": "9fdab84320453c55a4ce7c6fb335b122d5c88831165aa325221ae5323c149bd3",
         "size": 809
     },
     "lambdas/post-batch/requirements.txt": {
-        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
-        "size": 60
+        "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
+        "size": 79
     },
     "lambdas/post-batch/lambda_function.py": {
         "shasum": "205482cf492d9f06d691751750c75fa684ce8d9843f9c3ec342d001773fd29d7",
         "size": 1397
     },
     "lambdas/copy-assets/requirements.txt": {
-        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
-        "size": 60
+        "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
+        "size": 79
     },
     "lambdas/copy-assets/README.md": {
         "shasum": "7f2fb18a17278d9aa76b70410b9ac27fb0c311f338b5c9fed847ea2d1b0dde26",
@@ -44,8 +44,8 @@
         "size": 1856
     },
     "lambdas/feed-stac-api/requirements.txt": {
-        "shasum": "1d1b8abaebb8da53b0ffa7cdcfdd90cdfd13b7d2430f52a5c25d8049149486fa",
-        "size": 81
+        "shasum": "a309d8565015ea4aacc7ad5559d28ccf34b3350ed3f9844d7db524dfa6386356",
+        "size": 100
     },
     "lambdas/feed-stac-api/README.md": {
         "shasum": "a5107a831d1dbae3ae6d00adf0412b79e67edcf2630ccf70e58fdb1817983626",
@@ -56,8 +56,8 @@
         "size": 4283
     },
     "lambdas/feed-s3-inventory/requirements.txt": {
-        "shasum": "27c9a414e1b95648c6cbe42c95d2dd82d59fc11d734f42dc6b32b588831bfe67",
-        "size": 73
+        "shasum": "e3b42b579df6805963cd56280b98db2208f3501576fb4e935546dc0284ada0de",
+        "size": 92
     },
     "lambdas/feed-s3-inventory/README.md": {
         "shasum": "ef297e110da57ba9500090c45a87398dc7c5fc95db111046a09300c791a809b8",
@@ -68,8 +68,8 @@
         "size": 7837
     },
     "lambdas/update-state/requirements.txt": {
-        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
-        "size": 60
+        "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
+        "size": 79
     },
     "lambdas/update-state/README.md": {
         "shasum": "c747c571fc2fdef80b4520b8f85b7edd93b92f3b0fa292410f326fcbfbcc9d6a",
@@ -80,8 +80,8 @@
         "size": 6018
     },
     "lambdas/publish/requirements.txt": {
-        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
-        "size": 60
+        "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
+        "size": 79
     },
     "lambdas/publish/README.md": {
         "shasum": "df46c55ffe39c090c2790c4e47ff8bd6bea814c796cf4f6479e97afa25b4f0e7",
@@ -96,16 +96,16 @@
         "size": 1403
     },
     "lambdas/api/requirements.txt": {
-        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
-        "size": 60
+        "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
+        "size": 79
     },
     "lambdas/api/lambda_function.py": {
         "shasum": "429d7270427916b47daef95ae508f132d4f48a1e0820527e93b6f095951c8abb",
         "size": 5557
     },
     "lambdas/feed-rerun/requirements.txt": {
-        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
-        "size": 60
+        "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
+        "size": 79
     },
     "lambdas/feed-rerun/README.md": {
         "shasum": "7e7ec9226f9d7eb4609f89dc9b46ffe92cffd5a7490ca6f8c77d9a3fce753813",
@@ -116,8 +116,8 @@
         "size": 2268
     },
     "lambdas/convert-to-cog/requirements.txt": {
-        "shasum": "6dd3d02e12884ba0c5438d083ff498e8c49b8cd2faf06c8afcd6b47ba24a1e5e",
-        "size": 94
+        "shasum": "37117d09918af3cae01d4cc4938df3e7ed92c72e8c4c17ace63c41a8c64a109f",
+        "size": 113
     },
     "lambdas/convert-to-cog/README.md": {
         "shasum": "1c63d41de084e813acfc6f3214367196eef567dbf636b3eb82b9d78f9f53dde3",
@@ -128,8 +128,8 @@
         "size": 4139
     },
     "lambdas/process/requirements.txt": {
-        "shasum": "ac34d57261fd70bfb4ddbd5a1bd3e54795f24a5975bdae04697de8b26fbb3e58",
-        "size": 60
+        "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
+        "size": 79
     },
     "lambdas/process/README.md": {
         "shasum": "396db431f2d8638f21094af3270b680c48276728d19416c759450018d7505844",
@@ -144,8 +144,8 @@
         "size": 2515
     },
     "lambdas/add-preview/requirements.txt": {
-        "shasum": "6dd3d02e12884ba0c5438d083ff498e8c49b8cd2faf06c8afcd6b47ba24a1e5e",
-        "size": 94
+        "shasum": "37117d09918af3cae01d4cc4938df3e7ed92c72e8c4c17ace63c41a8c64a109f",
+        "size": 113
     },
     "lambdas/add-preview/README.md": {
         "shasum": "a3b594f6f897742d38e6566f8be6cfe3c195fd4ed33077c7f3316f573b2345fe",
@@ -168,8 +168,8 @@
         "size": 6401
     },
     "cirrus/lib/utils.py": {
-        "shasum": "88731b87afd78d009964a681ad31ca7a354d654e28aecf10e64f0f8241feb430",
-        "size": 3816
+        "shasum": "7641e699e1abfdc52890a1c9d684b93eaa260e9234858747170f08559ed7a18d",
+        "size": 5084
     },
     "cirrus/lib/errors.py": {
         "shasum": "15c62d1e8015f09103937c5f400a9814c2d8c2cf01844e0c8e1fcbc49c473e9b",
@@ -180,7 +180,7 @@
         "size": 18304
     },
     "cirrus/lib/process_payload.py": {
-        "shasum": "d588bca9544f23892ed110277f2433db91f0b395256bbeba7b4cd1bdfbd423bc",
-        "size": 17827
+        "shasum": "6ec6c3ae1d1b4887099e0e8bb3c31b3710c99cef14a9ae509b4dc16727fc1992",
+        "size": 18180
     }
 }


### PR DESCRIPTION
This PR pulls in a cirrus-lib version that supports item filtering when chaining workflows, dependent on the merge of cirrus-geo/cirrus-lib#37 and the v0.6.1 release. Until those two conditions are met the tests will fail.

Closes #99.