### PR TITLE
Fix more docs build issues

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -14,37 +14,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: git describe
-        run: git --git-dir .git describe --long --tags --dirty
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install -v .
+          pip install .
           pip install -r requirements-docs.txt
       - name: Build documentation
         run: |
           cd ./docs
-          make gh-pages-update
-        env:
-          CIRRUS_VERSION: ${{ github.event.release.tag_name }}
-      - name: Commit documentation changes
+          make clean build CIRRUS_VERSION=$GITHUB_REF_NAME
+      - name: Copy documentation into gh-pages
         if: github.event_name != 'pull_request'
         run: |
-          cd gh-pages
+          cd ./docs
+          make gh-pages-copy gh-pages-versions-update CIRRUS_VERSION=$GITHUB_REF_NAME
+      - name: Commit gh-pages changes
+        if: github.event_name != 'pull_request'
+        run: |
+          cd ./docs/gh-pages
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add .
           git commit -m "CI doc updates" -a ||:
-      - name: Push changes
+      - name: Push gh-pages changes
         if: github.event_name != 'pull_request'
         uses: ad-m/github-push-action@master
         with:
           branch: gh-pages
-          directory: gh-pages
+          directory: ./docs/gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@ STAGEDIR = _src
 BUILDDIR = _build
 CONFFILE = src/conf.py
 INCLUDE  = src/index.include
-CIRRUS_VERSION ?= $(shell git rev-parse --abbrev-ref HEAD) 
+export CIRRUS_VERSION := $(or $(CIRRUS_VERSION),$(shell git rev-parse --abbrev-ref HEAD))
 
 gh-pages:
 	git worktree add gh-pages gh-pages
@@ -14,8 +14,8 @@ gh-pages/.nojekyll: gh-pages
 gh-pages/index.html: gh-pages/.nojekyll src/index.html
 	cp src/index.html $@
 
-gh-pages/$(CIRRUS_VERSION):
-	mkdir $@
+gh-pages/$(CIRRUS_VERSION): gh-pages
+	mkdir -p $@
 
 .PHONY: gh-pages-clean
 gh-pages-clean:
@@ -26,11 +26,11 @@ gh-pages-copy: gh-pages-clean gh-pages/$(CIRRUS_VERSION)
 	cp -r $(BUILDDIR)/html/* gh-pages/$(CIRRUS_VERSION)
 
 .PHONY:
-gh-pages-versions-update: gh-pages
+gh-pages-versions-update: gh-pages/index.html gh-pages
 	python3 update-versions.py gh-pages
 
 .PHONY: gh-pages-update
-gh-pages-update: clean build gh-pages/index.html gh-pages-copy gh-pages-versions-update
+gh-pages-update: clean build gh-pages-copy gh-pages-versions-update
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Still having a problem with the docs build. Seems to be two issues: passing in an empty version should still set the default version from the branch name, and also setting the version within the makefile isn't exported to the build.