### PR TITLE
support events from SNS

### DIFF
--- a/src/cirrus/builtins/functions/process/lambda_function.py
+++ b/src/cirrus/builtins/functions/process/lambda_function.py
@@ -56,7 +56,7 @@ def lambda_handler(event, context):
             }
             payloads.append(ProcessPayload(payload_json, update=True))
         else:
-            payloads.append(ProcessPayload(payload, update=True))
+            payloads.append(ProcessPayload.from_event(payload, update=True))
 
     if len(payloads) > 0:
         _payloads = ProcessPayloads(payloads)


### PR DESCRIPTION
PR as a fix or discussion starter:  

Not sure how often this comes up, but if a complicated workflow requires a large set of input Items, it can exceed the SNS message size limit (256kB as of this moment).  

Seems natural to use the handy uploading that `ProcessPayload(collection).get_payload` provides.  But that doesn't work with the current process lambda: 

https://github.com/cirrus-geo/cirrus-geo/blob/e07e899a82544cbad9711ec086db8ede45299ada/src/cirrus/builtins/functions/process/lambda_function.py#L59

which expects a ProcessPayload, and not an event.