### PR TITLE
Handling large payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+.python-version
 .pytest_cache/
 node_modules/
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid `States.DataLimitExceeded` error when `publish` or `post-batch` return
+  large payloads by returning `payload.get_payload()`.
+
+### Added
+
+- `process` lambda now supports s3 URL payloads from feeders.
+
 ## [v0.7.0] - 2022-09-12
 
 ### ⚠️ Breaking changes

--- a/src/cirrus/builtins/tasks/post-batch/definition.yml
+++ b/src/cirrus/builtins/tasks/post-batch/definition.yml
@@ -6,6 +6,15 @@ lambda:
   iamRoleStatements:
     - Effect: "Allow"
       Action:
+        - "s3:PutObject"
+      Resource:
+        - !Join
+          - ''
+          - - 'arn:aws:s3:::'
+            - ${self:provider.environment.CIRRUS_PAYLOAD_BUCKET}
+            - '*'
+    - Effect: "Allow"
+      Action:
         - logs:GetLogEvents
       Resource:
         - arn:aws:logs:#{AWS::Region}:#{AWS::AccountId}:log-group:/aws/batch/*

--- a/src/cirrus/builtins/tasks/post-batch/lambda_function.py
+++ b/src/cirrus/builtins/tasks/post-batch/lambda_function.py
@@ -16,7 +16,7 @@ ERROR_REGEX = re.compile(r"^(?:cirrus\.?lib\.errors\.)?(?:([\.\w]+):)?\s*(.*)")
 
 def lambda_handler(event, context):
     if "error" not in event:
-        return ProcessPayload.from_event(event)
+        return ProcessPayload.from_event(event).get_payload()
 
     error = event.get("error", {})
     cause = json.loads(error["Cause"])

--- a/src/cirrus/builtins/tasks/publish/definition.yml
+++ b/src/cirrus/builtins/tasks/publish/definition.yml
@@ -26,6 +26,15 @@ lambda:
             - "*"
     - Effect: "Allow"
       Action:
+        - "s3:PutObject"
+      Resource:
+        - !Join
+          - ''
+          - - 'arn:aws:s3:::'
+            - ${self:provider.environment.CIRRUS_PAYLOAD_BUCKET}
+            - '*'
+    - Effect: "Allow"
+      Action:
         - "s3:ListBucket"
         - "s3:GetObject"
         - "s3:GetBucketLocation"

--- a/src/cirrus/builtins/tasks/publish/lambda_function.py
+++ b/src/cirrus/builtins/tasks/publish/lambda_function.py
@@ -172,4 +172,4 @@ def lambda_handler(event, context):
         logger.error(msg, exc_info=True)
         raise Exception(msg) from err
 
-    return payload
+    return payload.get_payload()

--- a/src/cirrus/core/components/files/handlers.py
+++ b/src/cirrus/core/components/files/handlers.py
@@ -16,7 +16,7 @@ LAMBDA_TYPE = '{component_type}'
 def lambda_handler(event, context={{}}):
     payload = ProcessPayload.from_event(event)
     logger = get_task_logger(f'{{LAMBDA_TYPE}}.{name}', payload=payload)
-    return payload
+    return payload.get_payload()
 """.format
 
 

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -1,7 +1,7 @@
 {
   "serverless.yml": {
-    "shasum": "f591dbdecddcb18b7c9f33c8a18b5823df334b0ef543681ae8162ad881128949",
-    "size": 35974
+    "shasum": "45768e8901ec1b99b038ce0178c078e6f6cfc1889b6ab6e0ba8556375b1f5e46",
+    "size": 36468
   },
   "lambdas/pre-batch/requirements.txt": {
     "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -16,8 +16,8 @@
     "size": 79
   },
   "lambdas/post-batch/lambda_function.py": {
-    "shasum": "964f3d4f789fabee324d5ad491c0f1e836dc21d9a82d9ea04af7a60960c0100b",
-    "size": 1412
+    "shasum": "5c0ee9914f5ac42f63f8b5fe49301408f50135f45529b98bb56e4f1a957a5ba8",
+    "size": 1426
   },
   "lambdas/update-state/requirements.txt": {
     "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
@@ -40,8 +40,8 @@
     "size": 1140
   },
   "lambdas/publish/lambda_function.py": {
-    "shasum": "6f426d0b9390f92d2ed46b43ef8c4bfb0f9f2f5bb9c792764cd825aab2effd86",
-    "size": 5355
+    "shasum": "fa3cd74a5faa97875e6f2fa06df2f8f0cfc11308c86c5fffe51a49a8eb6d334e",
+    "size": 5369
   },
   "lambdas/api/api.yaml": {
     "shasum": "b9f5b5e1b52d0402c0db986123335395114658489b5175dfccecde886e13e994",

--- a/tests/cli/fixtures/build/serverless.yml
+++ b/tests/cli/fixtures/build/serverless.yml
@@ -374,6 +374,15 @@ functions:
     iamRoleStatements:
       - Effect: Allow
         Action:
+          - s3:PutObject
+        Resource:
+          - Fn::Join:
+              - ''
+              - - 'arn:aws:s3:::'
+                - ${self:provider.environment.CIRRUS_PAYLOAD_BUCKET}
+                - '*'
+      - Effect: Allow
+        Action:
           - logs:GetLogEvents
         Resource:
           - Fn::Sub: arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/batch/*
@@ -489,6 +498,15 @@ functions:
               - ''
               - - 'arn:aws:s3:::'
                 - ${self:provider.environment.CIRRUS_DATA_BUCKET}
+                - '*'
+      - Effect: Allow
+        Action:
+          - s3:PutObject
+        Resource:
+          - Fn::Join:
+              - ''
+              - - 'arn:aws:s3:::'
+                - ${self:provider.environment.CIRRUS_PAYLOAD_BUCKET}
                 - '*'
       - Effect: Allow
         Action:


### PR DESCRIPTION
1. Supports s3-url event from feeder.
2. Handle large payloads returned from `post-batch` and `publish` lambdas