### PR TITLE
Update remaining builtins to use `cirrus.lib2`

### DIFF
--- a/src/cirrus/builtins/functions/update-state/lambda_function.py
+++ b/src/cirrus/builtins/functions/update-state/lambda_function.py
@@ -4,9 +4,9 @@ from os import getenv
 
 import boto3
 
-from cirrus.lib.logging import get_task_logger
-from cirrus.lib.process_payload import ProcessPayload
-from cirrus.lib.statedb import StateDB
+from cirrus.lib2.logging import get_task_logger
+from cirrus.lib2.process_payload import ProcessPayload
+from cirrus.lib2.statedb import StateDB
 
 logger = get_task_logger("lambda_function.update-state", payload=tuple())
 
@@ -48,7 +48,11 @@ def workflow_completed(input_payload, output_payload, error):
     if not output_payload:
         return
     for next_payload in output_payload.next_payloads():
-        next_payload.publish_to_sns(PROCESS_SNS_TOPIC)
+        SNS_CLIENT.publish(
+            TopicArn=PROCESS_SNS_TOPIC,
+            Message=json.dumps(next_payload),
+        )
+        logger.debug(f"Published payload to {PROCESS_SNS_TOPIC}")
 
 
 def workflow_aborted(input_payload, output_payload, error):

--- a/src/cirrus/builtins/tasks/post-batch/lambda_function.py
+++ b/src/cirrus/builtins/tasks/post-batch/lambda_function.py
@@ -3,10 +3,10 @@ import re
 
 import boto3
 
-from cirrus.lib.logging import get_task_logger
-from cirrus.lib.process_payload import ProcessPayload
+from cirrus.lib2.logging import get_task_logger
+from cirrus.lib2.process_payload import ProcessPayload
 
-logger = get_task_logger("lambda_function.update-state", payload=tuple())
+logger = get_task_logger("task.post-batch", payload=tuple())
 
 BATCH_LOG_GROUP = "/aws/batch/job"
 LOG_CLIENT = boto3.client("logs")

--- a/src/cirrus/builtins/tasks/pre-batch/lambda_function.py
+++ b/src/cirrus/builtins/tasks/pre-batch/lambda_function.py
@@ -3,8 +3,8 @@ from os import getenv
 
 from boto3utils import s3
 
-from cirrus.lib.logging import get_task_logger
-from cirrus.lib.process_payload import ProcessPayload
+from cirrus.lib2.logging import get_task_logger
+from cirrus.lib2.process_payload import ProcessPayload
 
 # envvars
 PAYLOAD_BUCKET = getenv("CIRRUS_PAYLOAD_BUCKET")

--- a/src/cirrus/builtins/tasks/publish/lambda_function.py
+++ b/src/cirrus/builtins/tasks/publish/lambda_function.py
@@ -31,54 +31,74 @@ def sns_attributes(item) -> dict:
     # note that sns -> sqs supports only 10 message attributes
     # when not using raw mode, and we currently have 10 attrs
     # possible
-    attr = {
-        "collection": {"DataType": "String", "StringValue": item["collection"]},
-        "bbox.ll_lon": {"DataType": "Number", "StringValue": str(item["bbox"][0])},
-        "bbox.ll_lat": {"DataType": "Number", "StringValue": str(item["bbox"][1])},
-        "bbox.ur_lon": {"DataType": "Number", "StringValue": str(item["bbox"][2])},
-        "bbox.ur_lat": {"DataType": "Number", "StringValue": str(item["bbox"][3])},
-    }
+    attrs = {}
+
+    if "collection" in item:
+        attrs["collection"] = {"DataType": "String", "StringValue": item["collection"]}
+
+    if "bbox" in item:
+        attrs["bbox.ll_lon"] = {
+            "DataType": "Number",
+            "StringValue": str(item["bbox"][0]),
+        }
+        attrs["bbox.ll_lat"] = {
+            "DataType": "Number",
+            "StringValue": str(item["bbox"][1]),
+        }
+        attrs["bbox.ur_lon"] = {
+            "DataType": "Number",
+            "StringValue": str(item["bbox"][2]),
+        }
+        attrs["bbox.ur_lat"] = {
+            "DataType": "Number",
+            "StringValue": str(item["bbox"][3]),
+        }
+
+    if "properties" not in item:
+        return attrs
 
     if "start_datetime" in item["properties"]:
-        attr["start_datetime"] = {
+        attrs["start_datetime"] = {
             "DataType": "String",
             "StringValue": item["properties"]["start_datetime"],
         }
     elif "datetime" in item["properties"]:
-        attr["start_datetime"] = {
+        attrs["start_datetime"] = {
             "DataType": "String",
             "StringValue": item["properties"]["datetime"],
         }
 
     if "end_datetime" in item["properties"]:
-        attr["end_datetime"] = {
+        attrs["end_datetime"] = {
             "DataType": "String",
             "StringValue": item["properties"]["end_datetime"],
         }
     elif "datetime" in item["properties"]:
-        attr["end_datetime"] = {
+        attrs["end_datetime"] = {
             "DataType": "String",
             "StringValue": item["properties"]["datetime"],
         }
 
     if "datetime" in item["properties"]:
-        attr["datetime"] = {
+        attrs["datetime"] = {
             "DataType": "String",
             "StringValue": item["properties"]["datetime"],
         }
 
     if "eo:cloud_cover" in item["properties"]:
-        attr["cloud_cover"] = {
+        attrs["cloud_cover"] = {
             "DataType": "Number",
             "StringValue": str(item["properties"]["eo:cloud_cover"]),
         }
 
-    if item["properties"]["created"] != item["properties"]["updated"]:
-        attr["status"] = {"DataType": "String", "StringValue": "updated"}
+    if "created" not in item["properties"] or "updated" not in item["properties"]:
+        pass
+    elif item["properties"]["created"] != item["properties"]["updated"]:
+        attrs["status"] = {"DataType": "String", "StringValue": "updated"}
     else:
-        attr["status"] = {"DataType": "String", "StringValue": "created"}
+        attrs["status"] = {"DataType": "String", "StringValue": "created"}
 
-    return attr
+    return attrs
 
 
 def publish_items_to_sns(payload, topic_arn, logger):

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -40,8 +40,8 @@
     "size": 1140
   },
   "lambdas/publish/lambda_function.py": {
-    "shasum": "b39d767bb4cfa3a7f4fae4ada273fead640612099bd96d58f553d6bcd16aabed",
-    "size": 4968
+    "shasum": "6f426d0b9390f92d2ed46b43ef8c4bfb0f9f2f5bb9c792764cd825aab2effd86",
+    "size": 5355
   },
   "lambdas/api/api.yaml": {
     "shasum": "b9f5b5e1b52d0402c0db986123335395114658489b5175dfccecde886e13e994",

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -8,16 +8,16 @@
     "size": 79
   },
   "lambdas/pre-batch/lambda_function.py": {
-    "shasum": "1565d7d568f550335405a3d036c54765e293c50fd80fe8587eb7f6498526d464",
-    "size": 788
+    "shasum": "a25469732ad9b28f123a2d4e52cf95a09108555f472448ccb600445abdf600a0",
+    "size": 790
   },
   "lambdas/post-batch/requirements.txt": {
     "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
     "size": 79
   },
   "lambdas/post-batch/lambda_function.py": {
-    "shasum": "81d8a13c8db9541b79958ee6b19fe5b898052090526e9352215cb21655313f08",
-    "size": 1423
+    "shasum": "964f3d4f789fabee324d5ad491c0f1e836dc21d9a82d9ea04af7a60960c0100b",
+    "size": 1412
   },
   "lambdas/update-state/requirements.txt": {
     "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
@@ -28,8 +28,8 @@
     "size": 83
   },
   "lambdas/update-state/lambda_function.py": {
-    "shasum": "48637951816fb8f57d4d88caa9f205a23d0e5c86b76bcb519aad5038c39c77b9",
-    "size": 6952
+    "shasum": "c6d2723835ef9280b50f612c3c4944cbf622d3ccd2e0883943772f92bb8d6bc2",
+    "size": 7090
   },
   "lambdas/publish/requirements.txt": {
     "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
@@ -40,8 +40,8 @@
     "size": 1140
   },
   "lambdas/publish/lambda_function.py": {
-    "shasum": "189cb005d48690ce2ddcf1795d81fdf5ed7ee0b801e73e399a64ccb5654fba3c",
-    "size": 2126
+    "shasum": "b39d767bb4cfa3a7f4fae4ada273fead640612099bd96d58f553d6bcd16aabed",
+    "size": 4968
   },
   "lambdas/api/api.yaml": {
     "shasum": "b9f5b5e1b52d0402c0db986123335395114658489b5175dfccecde886e13e994",


### PR DESCRIPTION
Closes #170 and #177.

Note that I did not use stac-task, as some of the builtins work a bit lower-level, and that wasn't going to provide the right level of abstraction. Sticking with lib2 seemed most appropriate/easiest for the time being.

I also have not tested these changes. They are minimal and they should work, but we'll want to deploy to a real environment and see that they all work before cutting a release (and someday we'll add automated testing for all of them so we have confidence in such changes).