### PR TITLE
Remove process SNS topic

### DIFF
--- a/src/cirrus/builtins/cloudformation/resources.yml
+++ b/src/cirrus/builtins/cloudformation/resources.yml
@@ -1,10 +1,4 @@
 Resources:
-  # SNS Topic for adding input data to Cirrus
-  ProcessTopic:
-    Type: "AWS::SNS::Topic"
-    Properties:
-      TopicName: "#{AWS::StackName}-process"
-  # SNS Topic for adding input data to Cirrus
   PublishTopic:
     Type: "AWS::SNS::Topic"
     Properties:
@@ -27,31 +21,6 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: "#{AWS::StackName}-process-dead-letter"
-  ProcessQueuePolicy:
-    Type: AWS::SQS::QueuePolicy
-    Properties:
-      Queues:
-        - !Ref ProcessQueue
-      PolicyDocument:
-        Statement:
-          - Sid: allow-sqs-sendmessage
-            Effect: Allow
-            Principal:
-              AWS: "*"
-            Action: SQS:SendMessage
-            Resource: !GetAtt ProcessQueue.Arn
-            Condition:
-              ArnEquals:
-                aws:SourceArn:
-                  - !Ref ProcessTopic
-                  - !Ref PublishTopic
-  ProcessQueueSubsciption:
-    Type: AWS::SNS::Subscription
-    Properties:
-      Endpoint: !GetAtt ProcessQueue.Arn
-      Protocol: sqs
-      Region: "#{AWS::Region}"
-      TopicArn: !Ref ProcessTopic
   StateTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/src/cirrus/core/config/default.yml
+++ b/src/cirrus/core/config/default.yml
@@ -18,7 +18,7 @@ provider:
     CIRRUS_PAYLOAD_BUCKET: !Ref Payloads
     CIRRUS_STATE_DB: !Ref StateTable
     CIRRUS_STACK: "#{AWS::StackName}"
-    CIRRUS_PROCESS_TOPIC_ARN: !Ref ProcessTopic
+    CIRRUS_PROCESS_QUEUE_URL: !Ref ProcessQueue
     CIRRUS_PUBLISH_TOPIC_ARN: !Ref PublishTopic
     CIRRUS_FAILED_TOPIC_ARN: !Ref FailedTopic
     CIRRUS_INVALID_TOPIC_ARN: !Ref FailedTopic

--- a/tests/builtins/conftest.py
+++ b/tests/builtins/conftest.py
@@ -113,6 +113,6 @@ def workflow(stepfunctions, iam):
 
 @pytest.fixture(autouse=True)
 def env(queue, statedb, payloads):
-    os.environ["CIRRUS_PROCESS_QUEUE"] = queue["QueueUrl"]
+    os.environ["CIRRUS_PROCESS_QUEUE_URL"] = queue["QueueUrl"]
     os.environ["CIRRUS_STATE_DB"] = statedb
     os.environ["CIRRUS_PAYLOAD_BUCKET"] = payloads

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -1,7 +1,7 @@
 {
   "serverless.yml": {
-    "shasum": "e431b1613bf4e9dba10564355140fadaed2d4dfdad6f8c693b6962d2c9addb51",
-    "size": 36030
+    "shasum": "d1a08b61091d76f77c189061d7f02b419e8ad3e5eaa6afcd8c2714d810e4975a",
+    "size": 35019
   },
   "lambdas/pre-batch/requirements.txt": {
     "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
@@ -40,8 +40,8 @@
     "size": 83
   },
   "lambdas/update-state/lambda_function.py": {
-    "shasum": "4cae796f54b5192fbedc5ef0c9f5e9c7deb435175f5b9e2503f73919611b9205",
-    "size": 7180
+    "shasum": "9997cac09099ad95691abc3179e2d3c45684acf10db95b3a65b2c440309a0649",
+    "size": 7499
   },
   "lambdas/publish/requirements.txt": {
     "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
@@ -88,8 +88,8 @@
     "size": 1568
   },
   "lambdas/feed-rerun/lambda_function.py": {
-    "shasum": "73526ce091ee772f86b4b6c0358f12646e81d825673255b651ad029145fa2cd3",
-    "size": 2263
+    "shasum": "183f66a4045ac54d4e8279b36043c326632300f5c16de63612e01b2d49c39155",
+    "size": 2202
   },
   "lambdas/process/requirements.txt": {
     "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",

--- a/tests/cli/fixtures/build/serverless.yml
+++ b/tests/cli/fixtures/build/serverless.yml
@@ -21,8 +21,8 @@ provider:
       Ref: StateTable
     CIRRUS_STACK:
       Fn::Sub: ${AWS::StackName}
-    CIRRUS_PROCESS_TOPIC_ARN:
-      Ref: ProcessTopic
+    CIRRUS_PROCESS_QUEUE_URL:
+      Ref: ProcessQueue
     CIRRUS_PUBLISH_TOPIC_ARN:
       Ref: PublishTopic
     CIRRUS_FAILED_TOPIC_ARN:
@@ -120,8 +120,8 @@ functions:
         Ref: StateTable
       CIRRUS_STACK:
         Fn::Sub: ${AWS::StackName}
-      CIRRUS_PROCESS_TOPIC_ARN:
-        Ref: ProcessTopic
+      CIRRUS_PROCESS_QUEUE_URL:
+        Ref: ProcessQueue
       CIRRUS_PUBLISH_TOPIC_ARN:
         Ref: PublishTopic
       CIRRUS_FAILED_TOPIC_ARN:
@@ -206,8 +206,8 @@ functions:
         Ref: StateTable
       CIRRUS_STACK:
         Fn::Sub: ${AWS::StackName}
-      CIRRUS_PROCESS_TOPIC_ARN:
-        Ref: ProcessTopic
+      CIRRUS_PROCESS_QUEUE_URL:
+        Ref: ProcessQueue
       CIRRUS_PUBLISH_TOPIC_ARN:
         Ref: PublishTopic
       CIRRUS_FAILED_TOPIC_ARN:
@@ -291,8 +291,8 @@ functions:
         Ref: StateTable
       CIRRUS_STACK:
         Fn::Sub: ${AWS::StackName}
-      CIRRUS_PROCESS_TOPIC_ARN:
-        Ref: ProcessTopic
+      CIRRUS_PROCESS_QUEUE_URL:
+        Ref: ProcessQueue
       CIRRUS_PUBLISH_TOPIC_ARN:
         Ref: PublishTopic
       CIRRUS_FAILED_TOPIC_ARN:
@@ -355,8 +355,8 @@ functions:
         Ref: StateTable
       CIRRUS_STACK:
         Fn::Sub: ${AWS::StackName}
-      CIRRUS_PROCESS_TOPIC_ARN:
-        Ref: ProcessTopic
+      CIRRUS_PROCESS_QUEUE_URL:
+        Ref: ProcessQueue
       CIRRUS_PUBLISH_TOPIC_ARN:
         Ref: PublishTopic
       CIRRUS_FAILED_TOPIC_ARN:
@@ -407,8 +407,8 @@ functions:
         Ref: StateTable
       CIRRUS_STACK:
         Fn::Sub: ${AWS::StackName}
-      CIRRUS_PROCESS_TOPIC_ARN:
-        Ref: ProcessTopic
+      CIRRUS_PROCESS_QUEUE_URL:
+        Ref: ProcessQueue
       CIRRUS_PUBLISH_TOPIC_ARN:
         Ref: PublishTopic
       CIRRUS_FAILED_TOPIC_ARN:
@@ -454,8 +454,8 @@ functions:
         Ref: StateTable
       CIRRUS_STACK:
         Fn::Sub: ${AWS::StackName}
-      CIRRUS_PROCESS_TOPIC_ARN:
-        Ref: ProcessTopic
+      CIRRUS_PROCESS_QUEUE_URL:
+        Ref: ProcessQueue
       CIRRUS_PUBLISH_TOPIC_ARN:
         Ref: PublishTopic
       CIRRUS_FAILED_TOPIC_ARN:
@@ -514,8 +514,8 @@ functions:
         Ref: StateTable
       CIRRUS_STACK:
         Fn::Sub: ${AWS::StackName}
-      CIRRUS_PROCESS_TOPIC_ARN:
-        Ref: ProcessTopic
+      CIRRUS_PROCESS_QUEUE_URL:
+        Ref: ProcessQueue
       CIRRUS_PUBLISH_TOPIC_ARN:
         Ref: PublishTopic
       CIRRUS_FAILED_TOPIC_ARN:
@@ -662,9 +662,9 @@ resources:
             - Name: CIRRUS_STACK
               Value:
                 Fn::Sub: ${AWS::StackName}
-            - Name: CIRRUS_PROCESS_TOPIC_ARN
+            - Name: CIRRUS_PROCESS_QUEUE_URL
               Value:
-                Ref: ProcessTopic
+                Ref: ProcessQueue
             - Name: CIRRUS_PUBLISH_TOPIC_ARN
               Value:
                 Ref: PublishTopic
@@ -718,9 +718,9 @@ resources:
             - Name: CIRRUS_STACK
               Value:
                 Fn::Sub: ${AWS::StackName}
-            - Name: CIRRUS_PROCESS_TOPIC_ARN
+            - Name: CIRRUS_PROCESS_QUEUE_URL
               Value:
-                Ref: ProcessTopic
+                Ref: ProcessQueue
             - Name: CIRRUS_PUBLISH_TOPIC_ARN
               Value:
                 Ref: PublishTopic
@@ -741,11 +741,6 @@ resources:
           Image: cirrusgeo/run-lambda:0.2.1
         RetryStrategy:
           Attempts: 1
-    ProcessTopic:
-      Type: AWS::SNS::Topic
-      Properties:
-        TopicName:
-          Fn::Sub: ${AWS::StackName}-process
     PublishTopic:
       Type: AWS::SNS::Topic
       Properties:
@@ -773,39 +768,6 @@ resources:
       Properties:
         QueueName:
           Fn::Sub: ${AWS::StackName}-process-dead-letter
-    ProcessQueuePolicy:
-      Type: AWS::SQS::QueuePolicy
-      Properties:
-        Queues:
-          - Ref: ProcessQueue
-        PolicyDocument:
-          Statement:
-            - Sid: allow-sqs-sendmessage
-              Effect: Allow
-              Principal:
-                AWS: '*'
-              Action: SQS:SendMessage
-              Resource:
-                Fn::GetAtt:
-                  - ProcessQueue
-                  - Arn
-              Condition:
-                ArnEquals:
-                  aws:SourceArn:
-                    - Ref: ProcessTopic
-                    - Ref: PublishTopic
-    ProcessQueueSubsciption:
-      Type: AWS::SNS::Subscription
-      Properties:
-        Endpoint:
-          Fn::GetAtt:
-            - ProcessQueue
-            - Arn
-        Protocol: sqs
-        Region:
-          Fn::Sub: ${AWS::Region}
-        TopicArn:
-          Ref: ProcessTopic
     StateTable:
       Type: AWS::DynamoDB::Table
       Properties:
@@ -1155,9 +1117,9 @@ resources:
             - Name: CIRRUS_STACK
               Value:
                 Fn::Sub: ${AWS::StackName}
-            - Name: CIRRUS_PROCESS_TOPIC_ARN
+            - Name: CIRRUS_PROCESS_QUEUE_URL
               Value:
-                Ref: ProcessTopic
+                Ref: ProcessQueue
             - Name: CIRRUS_PUBLISH_TOPIC_ARN
               Value:
                 Ref: PublishTopic


### PR DESCRIPTION
Updates `feed-rerun` and `update-state` to send messages directly to the process SQS queue rather than to the process SNS topic. Removes the cloudformation resources for the SNS topic and related subscription.

Note that the tests do not exercise this code so this is so far untested.

We'll need to ensure the CHANGELOG is updated to reflect the fact that project `cirrus.yml` files will need to be updated with the removal of the SNS topic var and the addition of the queue URL var (see the default config template diff). We'll also want to provide a cloudformation snippet for an sns.yml file that replaces the removed resources, for any projects that need them temporarily until all feeders have been updated to use SQS. But I have a ton of CHANGELOG entries to add, so I'm saving that for one last update before release.

Closing #169.