### PR TITLE
DLQ for `update-state`

### DIFF
--- a/src/cirrus/builtins/cloudformation/resources.yml
+++ b/src/cirrus/builtins/cloudformation/resources.yml
@@ -21,6 +21,10 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: "#{AWS::StackName}-process-dead-letter"
+  UpdateStateDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: "#{AWS::StackName}-update-state-dead-letter"
   StateTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/src/cirrus/builtins/functions/update-state/definition.yml
+++ b/src/cirrus/builtins/functions/update-state/definition.yml
@@ -18,6 +18,9 @@ lambda:
               - FAILED
               - ABORTED
               - TIMED_OUT
+        deadLetterQueueArn: !GetAtt UpdateStateDLQ.Arn
+        retryPolicy:
+          maximumEventAge: 1800
   iamRoleStatements:
     - Effect: "Allow"
       Action:

--- a/tests/builtins/functions/test_update_state.py
+++ b/tests/builtins/functions/test_update_state.py
@@ -1,5 +1,8 @@
+import pytest
+
 from cirrus.test import run_function
 
 
 def test_empty_event():
-    run_function("update-state", {})
+    with pytest.raises(Exception):
+        run_function("update-state", {})

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -1,7 +1,7 @@
 {
   "serverless.yml": {
-    "shasum": "d1a08b61091d76f77c189061d7f02b419e8ad3e5eaa6afcd8c2714d810e4975a",
-    "size": 35019
+    "shasum": "0a09346f4c742c4421090dd94e087ff7fbc969719deb174c2b5b710865b831b6",
+    "size": 35328
   },
   "lambdas/pre-batch/requirements.txt": {
     "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",
@@ -40,8 +40,8 @@
     "size": 83
   },
   "lambdas/update-state/lambda_function.py": {
-    "shasum": "9997cac09099ad95691abc3179e2d3c45684acf10db95b3a65b2c440309a0649",
-    "size": 7499
+    "shasum": "377777b56aa05fe18c67145dcdfe5b4fe76e79935494cd716c5871c0ea7bde0d",
+    "size": 7197
   },
   "lambdas/publish/requirements.txt": {
     "shasum": "76941e32ac85dc575cd3ed7a73ac60e271a6d284634aba35cf7740bc009792ae",

--- a/tests/cli/fixtures/build/serverless.yml
+++ b/tests/cli/fixtures/build/serverless.yml
@@ -242,6 +242,12 @@ functions:
                 - FAILED
                 - ABORTED
                 - TIMED_OUT
+          deadLetterQueueArn:
+            Fn::GetAtt:
+              - UpdateStateDLQ
+              - Arn
+          retryPolicy:
+            maximumEventAge: 1800
     iamRoleStatements:
       - Effect: Allow
         Action:
@@ -768,6 +774,11 @@ resources:
       Properties:
         QueueName:
           Fn::Sub: ${AWS::StackName}-process-dead-letter
+    UpdateStateDLQ:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName:
+          Fn::Sub: ${AWS::StackName}-update-state-dead-letter
     StateTable:
       Type: AWS::DynamoDB::Table
       Properties:


### PR DESCRIPTION
Adds a DLQ for `update-state` and updates it to raise an exception parsing an event rather than swallowing the error in a log message.

I believe the tests will fail once #181 is merged, as it includes a placeholder test for `update-state` that assumes it will not raise an exception on empty input. The commit will therefore need to be updated once that PR is merged with an expectation of an exception in that test.

Again, this is untested due to lack of test coverage.

Closing #182.