### PR TITLE
Some bugfixes for 0.8.0

### DIFF
--- a/src/cirrus/builtins/functions/process/lambda_function.py
+++ b/src/cirrus/builtins/functions/process/lambda_function.py
@@ -35,18 +35,21 @@ def lambda_handler(event, context):
         logger.debug("payload: %s", defer(json.dumps, payload))
 
         try:
-            payloads.append(ProcessPayload(payload, set_id_if_missing=True))
+            payload = ProcessPayload(payload, set_id_if_missing=True)
         except Exception:
             logger.exception(
                 "Failed to convert to ProcessPayload: %s", json.dumps(payload)
             )
             failures.append(payload)
+        else:
+            payloads.append(payload)
 
         if is_sqs_message(message):
+            payload_id = payload.get("id", hash(json.dumps(payload)))
             try:
-                messages[payload["id"]].append(message)
+                messages[payload_id].append(message)
             except KeyError:
-                messages[payload["id"]] = [message]
+                messages[payload_id] = [message]
 
     processed_ids = set()
     if len(payloads) > 0:

--- a/src/cirrus/builtins/tasks/publish/lambda_function.py
+++ b/src/cirrus/builtins/tasks/publish/lambda_function.py
@@ -1,22 +1,29 @@
 import json
-from os import getenv
+import os
+from datetime import datetime, timezone
 
 import boto3
+from boto3utils import s3, secrets
+from botocore.exceptions import ClientError
 
 from cirrus.lib2.logging import get_task_logger
 from cirrus.lib2.process_payload import ProcessPayload
 from cirrus.lib2.statedb import StateDB
+from cirrus.lib2.utils import get_path
 
 # envvars
-DATA_BUCKET = getenv("CIRRUS_DATA_BUCKET")
-API_URL = getenv("CIRRUS_API_URL", None)
-PUBLISH_TOPIC_ARN = getenv("CIRRUS_PUBLISH_TOPIC_ARN", None)
+DATA_BUCKET = os.getenv("CIRRUS_DATA_BUCKET")
+API_URL = os.getenv("CIRRUS_API_URL", None)
+PUBLISH_TOPIC_ARN = os.getenv("CIRRUS_PUBLISH_TOPIC_ARN", None)
 # DEPRECATED - additional topics
-PUBLISH_TOPICS = getenv("CIRRUS_PUBLISH_SNS", None)
+PUBLISH_TOPICS = os.getenv("CIRRUS_PUBLISH_SNS", None)
 
 # Cirrus state db
 statedb = StateDB()
 snsclient = boto3.client("sns")
+
+# global dictionary of sessions per bucket
+s3_sessions = {}
 
 
 def sns_attributes(item) -> dict:
@@ -102,11 +109,6 @@ def sns_attributes(item) -> dict:
 
 
 def publish_items_to_sns(payload, topic_arn, logger):
-    """Publish this ProcessPayload's items to SNS
-
-    Args:
-        topic_arn (str, optional): ARN of SNS Topic. Defaults to PUBLISH_TOPIC_ARN.
-    """
     responses = []
     for item in payload["features"]:
         responses.append(
@@ -118,6 +120,89 @@ def publish_items_to_sns(payload, topic_arn, logger):
         )
         logger.debug(f"Published item to {topic_arn}")
     return responses
+
+
+def get_s3_session(s3url: str, logger) -> s3:
+    """Get boto3-utils s3 class for interacting with an s3 bucket. A secret will be looked for with the name
+    `cirrus-creds-<bucket-name>`. If no secret is found the default session will be used
+
+    Args:
+        s3url (str, optional): The s3 URL to access. Defaults to None.
+
+    Returns:
+        s3: A boto3-utils s3 class
+    """
+    parts = s3.urlparse(s3url)
+    bucket = parts["bucket"]
+
+    if bucket and bucket in s3_sessions:
+        return s3_sessions[bucket]
+
+    creds = {}
+    try:
+        # get credentials from AWS secret
+        secret_name = f"cirrus-creds-{bucket}"
+        creds = secrets.get_secret(secret_name)
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "ResourceNotFoundException":
+            # some other client error we cannot handle
+            raise e
+        logger.info(f"Secret not found, using default credentials: '{secret_name}'")
+
+    requester_pays = creds.pop("requester_pays", False)
+    session = boto3.Session(**creds)
+    s3_sessions[bucket] = s3(session, requester_pays=requester_pays)
+    return s3_sessions[bucket]
+
+
+def publish_items_to_s3(payload, bucket, public, logger) -> list:
+    opts = payload.process.get("upload_options", {})
+    s3urls = []
+    for item in payload["features"]:
+        # determine URL of data bucket to publish to- always do this
+        url = os.path.join(
+            get_path(item, opts.get("path_template")), f"{item['id']}.json"
+        )
+        if url[0:5] != "s3://":
+            url = f"s3://{bucket}/{url.lstrip('/')}"
+        if public:
+            url = s3.s3_to_https(url)
+
+        # add canonical and self links (and remove existing self link if present)
+        item["links"] = [
+            link for link in item["links"] if link["rel"] not in ["self", "canonical"]
+        ]
+        item["links"].insert(
+            0, {"rel": "canonical", "href": url, "type": "application/json"}
+        )
+        item["links"].insert(
+            0, {"rel": "self", "href": url, "type": "application/json"}
+        )
+
+        # get s3 session
+        s3session = get_s3_session(url, logger)
+
+        # if existing item use created date
+        now = datetime.now(timezone.utc).isoformat()
+        created = None
+        if s3session.exists(url):
+            old_item = s3session.read_json(url)
+            created = old_item["properties"].get("created", None)
+        if created is None:
+            created = now
+        item["properties"]["created"] = created
+        item["properties"]["updated"] = now
+
+        # publish to bucket
+        headers = opts.get("headers", {})
+
+        extra = {"ContentType": "application/json"}
+        extra.update(headers)
+        s3session.upload_json(item, url, public=public, extra=extra)
+        s3urls.append(url)
+        logger.info("Published to s3")
+
+    return s3urls
 
 
 def lambda_handler(event, context):
@@ -147,7 +232,7 @@ def lambda_handler(event, context):
                 item["links"].append(link)
 
         # publish to s3
-        s3urls = payload.publish_items_to_s3(DATA_BUCKET, public=public)
+        s3urls = publish_items_to_s3(payload, DATA_BUCKET, public, logger)
 
         # publish to Cirrus SNS publish topic
         publish_items_to_sns(payload, PUBLISH_TOPIC_ARN, logger)

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -104,8 +104,8 @@
     "size": 26
   },
   "lambdas/process/lambda_function.py": {
-    "shasum": "07269e39e68b812dc743aec8336add723dd513de0112ea53dcad6d1e78670746",
-    "size": 2493
+    "shasum": "9c5d728c98425d0ea2ed6e760695cac4d96873c169c5d12597b0dd00383fc858",
+    "size": 2601
   },
   "cirrus/lib2/logging.py": {
     "shasum": "755b3c26ba2e555e5bb4a6d184cded2f2c01586ec891453e62c7a941a79b40a6",

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -56,8 +56,8 @@
     "size": 1140
   },
   "lambdas/publish/lambda_function.py": {
-    "shasum": "fa3cd74a5faa97875e6f2fa06df2f8f0cfc11308c86c5fffe51a49a8eb6d334e",
-    "size": 5369
+    "shasum": "4e08a8d0e8c95acd409a813a68f75dc56b4d81ae6c9c2f91ec021f1d13c4da73",
+    "size": 8306
   },
   "lambdas/api/api.yaml": {
     "shasum": "b9f5b5e1b52d0402c0db986123335395114658489b5175dfccecde886e13e994",
@@ -116,8 +116,8 @@
     "size": 0
   },
   "cirrus/lib2/utils.py": {
-    "shasum": "b8b4d13b43692428dcefa26b03f8b427552c4c7459d24dde24f0803ae3338759",
-    "size": 7288
+    "shasum": "51875e762abd92f34ec4154989308c1c8decb0f85837db6d5df8d0e06ed0f7b0",
+    "size": 8493
   },
   "cirrus/lib2/errors.py": {
     "shasum": "2f6699dd2f40f4ac17fcf7438efe7b0716604752a76dbb19c100778c322dd129",

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -128,8 +128,8 @@
     "size": 20067
   },
   "cirrus/lib2/process_payload.py": {
-    "shasum": "505c775c21b8345105ac083eab34496216ee5cc21d52a0bd92759203a6691f7a",
-    "size": 13776
+    "shasum": "b5347139d949ec8921a80d7a25ef941815503557f9cc6b7add96c1db7f421fa9",
+    "size": 14036
   },
   "cirrus/lib/logging.py": {
     "shasum": "f578f6385a2270dcee92c2b18d541f4d68dae5950e878193c253f7aa5fedeb0d",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3,6 +3,7 @@ import json
 import os
 import os.path
 import shlex
+import shutil
 from pathlib import Path
 
 import pytest
@@ -67,14 +68,14 @@ def reference_build(fixtures, build_dir):
     # pass ref dir to test if we have one
     yield reference if has_ref else None
     # else we can copy test output to serve as reference
-    if not has_ref:
-        reference.mkdir()
-        reference.joinpath("hashes.json").write_text(
-            json.dumps(hash_tree(build_dir), indent=2) + "\n",
-        )
-        reference.joinpath("serverless.yml").write_bytes(
-            build_dir.joinpath("serverless.yml").read_bytes(),
-        )
+    shutil.rmtree(reference, ignore_errors=True)
+    reference.mkdir()
+    reference.joinpath("hashes.json").write_text(
+        json.dumps(hash_tree(build_dir), indent=2) + "\n",
+    )
+    reference.joinpath("serverless.yml").write_bytes(
+        build_dir.joinpath("serverless.yml").read_bytes(),
+    )
 
 
 def test_init(invoke, project_testdir):


### PR DESCRIPTION
Closing #185 by resolving the dependence of `process` on a payload ID. Also fixes an issue with `publish` related to the work for #177 and some functions that were missed in switching to lib2.

One last change I happened to bundle in here (though I should probably have split it out but oh well) is updating the build test to overwrite the fixture files. The idea there is that 1) contributors often are not sure what to do to update the fixtures to get the test to pass, and 2) we can use this as a pre-commit hook now that will stage changes for the fixture updates and block committing without them. But I want to play around with that before making that an official part of the pre-commit hook.

Added one more change re #177 fixing a problem with `ProcessPayload.from_event()` which was preventing it from resolving payload URLs, which broke `post-batch`.