### PR TITLE
drop support for python 3.7

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ dependency_links = [x.strip().replace("git+", "") for x in reqs if "git+" not in
 
 setup(
     name="cirrus-geo",
+    python_requires=">=3.8",
     packages=find_namespace_packages("src"),
     package_dir={"": "src"},
     version=VERSION,
@@ -79,9 +80,9 @@ setup(
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     license="Apache-2.0",
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
     ],
     license="Apache-2.0",
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ dependency_links = [x.strip().replace("git+", "") for x in reqs if "git+" not in
 
 setup(
     name="cirrus-geo",
-    python_requires=">=3.8,<=3.9",
+    python_requires=">=3.8",
     packages=find_namespace_packages("src"),
     package_dir={"": "src"},
     version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ dependency_links = [x.strip().replace("git+", "") for x in reqs if "git+" not in
 
 setup(
     name="cirrus-geo",
-    python_requires=">=3.8",
+    python_requires=">=3.8,<=3.9",
     packages=find_namespace_packages("src"),
     package_dir={"": "src"},
     version=VERSION,


### PR DESCRIPTION
Drops support for Python 3.7.

- Add a python version restriction in the setup.py
- Removes 3.7 from the GH testing matrix, and adds 3.11 (even though this version is not supported in AWS Lambda yet, as 3.10 also is not, but it allows us to catch issues with newer versions earlier)
