### PR TITLE
set execution arn when setting completed

### DIFF
--- a/src/cirrus/builtins/functions/update-state/lambda_function.py
+++ b/src/cirrus/builtins/functions/update-state/lambda_function.py
@@ -120,7 +120,7 @@ def workflow_completed(execution: Execution) -> None:
     # trying the sns publish, but I could see it the other
     # way too. If we have issues here we might want to consider
     # a different order/behavior (fail on error or something?).
-    statedb.set_completed(execution.input["id"])
+    statedb.set_completed(execution.input["id"], execution_arn=execution.arn)
     if execution.output:
         with batch_handler(send_batch, {}, "messages", batch_size=10) as handler:
             for next_payload in execution.output.next_payloads():

--- a/src/cirrus/lib2/statedb.py
+++ b/src/cirrus/lib2/statedb.py
@@ -369,6 +369,8 @@ class StateDB:
 
         if execution_arn:
             self.write_timeseries_record(key, StateEnum.COMPLETED, now, execution_arn)
+        else:
+            logger.debug("set completed called with no execution ARN")
 
         return response
 

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -40,8 +40,8 @@
     "size": 83
   },
   "lambdas/update-state/lambda_function.py": {
-    "shasum": "edf5a22dc4483d341a03cba02404de523dc0e425ad79a8e82a325d70511594fd",
-    "size": 7373
+    "shasum": "7a075a056950c65adab107a79f0556c292c504c2ce88089e261aa962b3f53b97",
+    "size": 7402
   },
   "lambdas/publish/requirements.txt": {
     "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",
@@ -128,8 +128,8 @@
     "size": 106
   },
   "cirrus/lib2/statedb.py": {
-    "shasum": "ee05309f9fac48881695992ef5f4d80fda7c1d440373df3b3c33aa694f8d4007",
-    "size": 21946
+    "shasum": "5ee0a60f209e99f12c1bafd64018829f9b3e672d79a460335b7bba71c58456bb",
+    "size": 22031
   },
   "cirrus/lib2/process_payload.py": {
     "shasum": "b5347139d949ec8921a80d7a25ef941815503557f9cc6b7add96c1db7f421fa9",


### PR DESCRIPTION
The execution_arn parameter wasn't passed to set_completed, now it is.