### PR TITLE
update MANIFEST.in to include requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Include `requirements.txt` for install from source distribution. This was
+  missing and prevented install from pypi source.
+
 ## [v0.9.0] - 2023-01-26
 
 ### ⚠️ Breaking changes

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include requirements.txt
 recursive-include src *
 global-exclude *.py[cod]


### PR DESCRIPTION
This fixes install via source distribution.  There may be a reason to _not_ distribute in source form, in which case this can be closed and ignored. 

In absence of requirements.txt, installation from source distribution via pypi is not possible:
```shell
% pip install cirrus-geo==0.9.0  --no-binary cirrus-geo
DEPRECATION: --no-binary currently disables reading from the cache of locally built wheels. In the future --no-binary will not influence the wheel cache. pip 23.1 will enforce this behaviour change. A possible replacement is to use the --no-cache-dir option. You can use the flag --use-feature=no-binary-enable-wheel-cache to test the upcoming behaviour. Discussion can be found at https://github.com/pypa/pip/issues/11453
Collecting cirrus-geo==0.9.0
  Downloading cirrus-geo-0.9.0.tar.gz (186 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 186.1/186.1 kB 4.1 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/2j/fg4r5bgj5rj39sdb3dsw9b5h0000gn/T/pip-install-mw3hbrb4/cirrus-geo_1857b69683414f82a330ecd1f26044d6/setup.py", line 60, in <module>
          with open(os.path.join(HERE, "requirements.txt"), encoding="utf-8") as f:
      FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/2j/fg4r5bgj5rj39sdb3dsw9b5h0000gn/T/pip-install-mw3hbrb4/cirrus-geo_1857b69683414f82a330ecd1f26044d6/requirements.txt'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```