### PR TITLE
Fix doc builder and fix links on readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,14 +199,12 @@ available to developers for writing their own tasks.
 ## Documentation
 
 Documentation for deploying, using, and customizing Cirrus is contained
-within the [docs](docs/) directory:
+within the [docs](https://cirrus-geo.github.io/cirrus-geo/) directory:
 
-- Understand the [architecture](docs/architecture.md) of Cirrus and key concepts
-- [Deploy](docs/deployment.md) Cirrus to your own AWS account
-- [Use](docs/usage.md) Cirrus to process input data and publish resulting
-  STAC Items
-- [Customize](docs/customize.md) Cirrus by adding tasks, workflows,
-  and compute environments
+- Learn how to [get started](https://cirrus-geo.github.io/cirrus-geo/stable/cirrus/10_intro.html)
+- Understand the [architecture](https://cirrus-geo.github.io/cirrus-geo/stable/cirrus/20_arch.html) of Cirrus and key concepts
+- [Use](https://cirrus-geo.github.io/cirrus-geo/stable/cirrus/30_payload.html) Cirrus to process input data and publish resulting STAC Items
+- Cirrus features several [component types](https://cirrus-geo.github.io/cirrus-geo/stable/cirrus/60_components.html) that each represent a specific role within the Cirrus architecture
 
 ## About
 

--- a/docs/update-versions.py
+++ b/docs/update-versions.py
@@ -23,11 +23,12 @@ def main(gh_pages_dir):
     gh_pages_dir = Path(gh_pages_dir)
 
     all_versions = set()
-    stable_version = parse("")
+    stable_version = parse("0.0")
     for _file in gh_pages_dir.iterdir():
         if _file.is_dir():
-            version = parse(_file.name)
-            if not isinstance(version, Version):
+            try:
+                version = parse(_file.name)
+            except:
                 continue
             version.name = _file.name
             all_versions.add(version.name)

--- a/docs/update-versions.py
+++ b/docs/update-versions.py
@@ -23,7 +23,8 @@ def main(gh_pages_dir):
     gh_pages_dir = Path(gh_pages_dir)
 
     all_versions = set()
-    stable_version = parse("0.0")
+    default_version = parse("0.0")
+    stable_version = default_version
     for _file in gh_pages_dir.iterdir():
         if _file.is_dir():
             try:
@@ -40,7 +41,7 @@ def main(gh_pages_dir):
     # create 'stable' redirect to most-recent non-prerelease version
     stable = gh_pages_dir.joinpath(STABLE_LINK_NAME)
     stable.unlink(missing_ok=True)
-    if stable_version:
+    if stable_version != default_version:
         stable.symlink_to(stable_version)
         all_versions.add(STABLE_LINK_NAME)
 


### PR DESCRIPTION
Fixes #212 

I was experiencing the same broken action on my fork. 
<img width="983" alt="image" src="https://user-images.githubusercontent.com/3211707/223915783-d6696503-0a92-4331-908b-db44db768623.png">

The changes fix the errors
<img width="582" alt="image" src="https://user-images.githubusercontent.com/3211707/223916005-9ff3a2fc-523a-4bc5-a349-c2e6a6e047da.png">

Im not sure why this worked before but `parse()` was failing on strings like `""` and `main`. 

I also fixed some links on the readme - and adjust the text to match the documentation. 
<img width="503" alt="image" src="https://user-images.githubusercontent.com/3211707/223916205-0017113d-6036-440d-a2a1-b8b15486811c.png">
