### PR TITLE
fixes batch tasks using stac-task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v0.9.1] - 2023-07-14
+
 ### Fixed
 
 - Include `requirements.txt` for install from source distribution. This was
   missing and prevented install from pypi source.
+- For Batch tasks in workflows, the output payload URL is now explicitly set in the pre-batch lambda
+so that the URL is in the Parameters list of the output, rather than the post-batch function
+having to infer the output payload URL.  This fixes Batch tasks when using stac-task.
+Any JobDefinition using stac-task should specify `url` and `url_out` as Parameters and specify --output
+in the Command, e.g.:
+
+```
+    Parameters:
+      url: ""
+      url_out: ""
+    ContainerProperties:
+      Command:
+        - task
+        - run
+        - Ref::url
+        - --output
+        - Ref::url_out
+```
+
 
 ## [v0.9.0] - 2023-01-26
 
@@ -617,7 +638,8 @@ cleanup steps.
 
 Initial release
 
-[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.9.0...main
+[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.9.1...main
+[v0.9.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.9.0...v0.9.1
 [v0.9.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.8.0...v0.9.0
 [v0.8.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.7.0...v0.8.0
 [v0.7.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.6.0...v0.7.0

--- a/src/cirrus/builtins/tasks/pre-batch/lambda_function.py
+++ b/src/cirrus/builtins/tasks/pre-batch/lambda_function.py
@@ -15,13 +15,17 @@ def lambda_handler(event, context):
     logger = get_task_logger("task.pre-batch", payload=payload)
 
     url = f"s3://{PAYLOAD_BUCKET}/batch/{payload['id']}/{uuid.uuid1()}.json"
+    url_out = url.replace(".json", "_out.json")
 
     try:
         # copy payload to s3
         s3().upload_json(payload, url)
 
         logger.debug(f"Uploaded payload to {url}")
-        return {"url": url}
+        return {
+            "url": url,
+            "url_out": url_out
+        }
     except Exception as err:
         msg = f"pre-batch: failed pre processing batch job for ({err})"
         logger.error(msg, exc_info=True)

--- a/src/cirrus/lib2/utils.py
+++ b/src/cirrus/lib2/utils.py
@@ -168,9 +168,10 @@ def extract_record(record):
     if "Message" in record:
         record = json.loads(record["Message"])
 
-    if "url" not in record and "Parameters" in record and "url" in record["Parameters"]:
+    if "url" not in record and "Parameters" in record:
         # this is Batch, get the output payload
-        record = {"url": record["Parameters"]["url"].replace(".json", "_out.json")}
+        if "url_out" in record["Parameters"]:
+            record = {"url": record["Parameters"]["url_out"]}
 
     return record
 

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -12,8 +12,8 @@
     "size": 0
   },
   "lambdas/pre-batch/lambda_function.py": {
-    "shasum": "a25469732ad9b28f123a2d4e52cf95a09108555f472448ccb600445abdf600a0",
-    "size": 790
+    "shasum": "0f4338592635f867c910ccecefe7a6a42de80bed8274a88a9a699c469ec83317",
+    "size": 892
   },
   "lambdas/post-batch/requirements.txt": {
     "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",
@@ -120,8 +120,8 @@
     "size": 7003
   },
   "cirrus/lib2/utils.py": {
-    "shasum": "a4ff0ad560b09fab5686e8f0c6dca6f97d170103749e400dfb4eee376fbf97d5",
-    "size": 8984
+    "shasum": "2ed2989f8e3f38e5e0e0b72f671cf6ccc9171958c17a2be186293d69bdfb9b8d",
+    "size": 8974
   },
   "cirrus/lib2/errors.py": {
     "shasum": "2f6699dd2f40f4ac17fcf7438efe7b0716604752a76dbb19c100778c322dd129",

--- a/tests/lib/fixtures/events/plain-batch-url.json
+++ b/tests/lib/fixtures/events/plain-batch-url.json
@@ -1,5 +1,6 @@
 {
   "Parameters": {
-    "url": "s3://payloads/test-payload.json"
+    "url": "s3://payloads/test-payload.json",
+    "url_out": "s3://payloads/test-payload_out.json"
   }
 }


### PR DESCRIPTION
This fixes batch tasks using the stac-task library.

The post-batch Lambda expects an output payload with the same URL as the input payload except ending in `_out.json` rather than `.json`.  However, stac-task requires specifying the output payload URL explicitly which was not possible in the JobDefinition of the CloudFormation files.

This PR has the pre-batch Lambda passing both a `url` and `url_out` parameter to the Batch task so that `url_out` can be passed to the stac-task CLI.  The post batch Lambda then looks at the parameters to get the `url_out` to read the payload from.

JobDefinition's using stac-task should be structured like:

```
    Parameters:
      url: ""
      url_out: ""
    ContainerProperties:
      Command:
        - task
        - run
        - Ref::url
        - --output
        - Ref::url_out
```