### PR TITLE
update pyyaml to 6.0 to support python 3.10 and 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml~=5.4
+pyyaml~=6.0
 click~=8.0
 click-plugins~=1.1
 rich~=10.6


### PR DESCRIPTION
Per this issue:

- https://github.com/yaml/pyyaml/issues/601

pyyaml needs to be updated to build correctly under 3.10 and 3.11.