### PR TITLE
fix #223

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure correct count returned from `process` lambda and resolve
+  `UnboundLocalError` encountered on certain workflow failures. ([#224])
+
 ## [v0.10.0] - 2023-07-19
 
 ### ⚠️ Breaking changes
@@ -723,6 +728,7 @@ Initial release
 [#138]: https://github.com/cirrus-geo/cirrus-geo/pull/138
 [#143]: https://github.com/cirrus-geo/cirrus-geo/pull/143
 [#160]: https://github.com/cirrus-geo/cirrus-geo/pull/160
+[#224]: https://github.com/cirrus-geo/cirrus-geo/pull/224
 [f25acd4f]: https://github.com/cirrus-geo/cirrus-geo/commit/f25acd4f43e2d8e766ff8b2c3c5a54606b1746f2
 [85464f5]: https://github.com/cirrus-geo/cirrus-geo/commit/85464f5a7cb3ef82bc93f6f1314e98b4af6ff6c1
 [1b89611]: https://github.com/cirrus-geo/cirrus-geo/commit/1b89611125e2fa852554951343731d1682dd3c4c

--- a/src/cirrus/builtins/functions/process/lambda_function.py
+++ b/src/cirrus/builtins/functions/process/lambda_function.py
@@ -54,6 +54,7 @@ def lambda_handler(event, context):
                 messages[payload_id] = [message]
 
     processed_ids = set()
+    processed = {"started": []}
     if len(payloads) > 0:
         processed = ProcessPayloads(payloads).process()
         processed_ids = {pid for state in processed.keys() for pid in processed[state]}

--- a/src/cirrus/lib2/process_payload.py
+++ b/src/cirrus/lib2/process_payload.py
@@ -380,11 +380,11 @@ class ProcessPayloads:
                     payload_id = payload()
                 except TerminalError:
                     payload_ids["failed"].append(payload["id"])
-
-                if payload_id is not None:
-                    payload_ids["started"].append(payload_id)
                 else:
-                    payload_ids["skipped"].append(payload["id"])
+                    if payload_id is not None:
+                        payload_ids["started"].append(payload_id)
+                    else:
+                        payload_ids["skipped"].append(payload["id"])
             else:
                 logger.info(f"Skipping {payload['id']}, input already in {state} state")
                 payload_ids["skipped"].append(payload["id"])

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -104,8 +104,8 @@
     "size": 26
   },
   "lambdas/process/lambda_function.py": {
-    "shasum": "cafb12bb5b32f46ca6d7af6437fb6360756a32633c06ca58f8ace67bcf8c77fd",
-    "size": 2595
+    "shasum": "341190902c9c48555f9a5615a088c25fc327c02fdffd9328ee121d61630d8b03",
+    "size": 2627
   },
   "cirrus/lib2/logging.py": {
     "shasum": "bee855ad35595b58e26bb094e0e516eed2e98337a4817d6543e7d49e7cfa8a97",
@@ -132,8 +132,8 @@
     "size": 22034
   },
   "cirrus/lib2/process_payload.py": {
-    "shasum": "b5347139d949ec8921a80d7a25ef941815503557f9cc6b7add96c1db7f421fa9",
-    "size": 14036
+    "shasum": "fa8177acf9ec13f089ea4cb15df31f3aa0cf22a3c445176660d9a1822c9c44bc",
+    "size": 14073
   },
   "cirrus/lib/logging.py": {
     "shasum": "f578f6385a2270dcee92c2b18d541f4d68dae5950e878193c253f7aa5fedeb0d",


### PR DESCRIPTION
I also found out that the problem was manifesting in wrong processed count being returned from the `process` lambda because in certain cases failures were also being counted as started workflows. Upon realizing that, I thought using an `else` on the `try`/`except` would be a better solution than `continue` to remove ambiguity in whether `payload_id` had a value from the current or previous loop.