### PR TITLE
purge old external cirrus.lib package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Cleaned `cirrus.lib` (old separate package) from lambda templates and build
+  process. ([#230])
+
 ### Fixed
 
 - Ensure correct count returned from `process` lambda and resolve

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ click~=8.0
 click-plugins~=1.1
 rich~=10.6
 cfn-flip~=1.2
-cirrus-lib~=0.8.1
 boto3-utils~=0.4.1
 boto3>=1.26.0
 python-json-logger~=2.0

--- a/src/cirrus/core/components/files/handlers.py
+++ b/src/cirrus/core/components/files/handlers.py
@@ -6,8 +6,8 @@ logger = logging.getLogger(__name__)
 
 
 default_handler = """#!/usr/bin/env python
-from cirrus.lib.process_payload import ProcessPayload
-from cirrus.lib.logging import get_task_logger
+from cirrus.lib2.process_payload import ProcessPayload
+from cirrus.lib2.logging import get_task_logger
 
 
 LAMBDA_TYPE = '{component_type}'

--- a/src/cirrus/core/config/__init__.py
+++ b/src/cirrus/core/config/__init__.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from cirrus.core.constants import DEFAULT_CONFIG_FILENAME, SERVERLESS_PLUGINS
 from cirrus.core.exceptions import ConfigError
-from cirrus.core.utils import misc
 from cirrus.core.utils.yaml import NamedYamlable
 
 logger = logging.getLogger(__name__)
@@ -38,16 +37,13 @@ class Config(NamedYamlable):
         self.package.exclude = []
         self.package.exclude.append("**/*")
 
-        # add cirrus-lib dependencies as global
+        # add pythonRequirements section for global needs
         if "custom" not in self:
             self.custom = {}
         if "pythonRequirements" not in self.custom:
             self.custom.pythonRequirements = {}
         if "include" not in self.custom.pythonRequirements:
             self.custom.pythonRequirements.include = []
-        self.custom.pythonRequirements.include.extend(
-            misc.get_cirrus_lib_requirements(),
-        )
 
         # populate required plugin list
         try:

--- a/src/cirrus/core/project.py
+++ b/src/cirrus/core/project.py
@@ -128,7 +128,6 @@ class Project:
 
         import shutil
 
-        import cirrus.lib
         import cirrus.lib2
         from cirrus.core.utils import misc
 
@@ -159,14 +158,6 @@ class Project:
         # write serverless config
         self.config.build(self.groups).to_file(
             bd.joinpath(DEFAULT_SERVERLESS_FILENAME),
-        )
-
-        # copy cirrus-lib to build dir for packaging
-        lib_dir = bd.joinpath("cirrus", "lib")
-        shutil.copytree(
-            cirrus.lib.__path__[0],
-            lib_dir,
-            ignore=shutil.ignore_patterns("*.pyc", "__pycache__"),
         )
 
         # copy built-in lib2 to build dir for packaging

--- a/src/cirrus/core/utils/misc.py
+++ b/src/cirrus/core/utils/misc.py
@@ -1,22 +1,6 @@
 import os
 import os.path
 from pathlib import Path
-from typing import List
-
-
-def get_cirrus_lib_requirements() -> List[str]:
-    """
-    Get the cirrus-lib dependencies.
-    """
-    try:
-        from importlib import metadata
-    except ImportError:
-        import importlib_metadata as metadata
-
-    return [
-        req.split(";")[0].translate(str.maketrans("", "", " ()"))
-        for req in metadata.requires("cirrus-lib")
-    ]
 
 
 def relative_to(path1: Path, path2: Path) -> Path:

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -4,8 +4,8 @@
     "size": 37964
   },
   "lambdas/pre-batch/requirements.txt": {
-    "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",
-    "size": 79
+    "shasum": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    "size": 1
   },
   "lambdas/pre-batch/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -16,8 +16,8 @@
     "size": 892
   },
   "lambdas/post-batch/requirements.txt": {
-    "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",
-    "size": 79
+    "shasum": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    "size": 1
   },
   "lambdas/post-batch/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -28,8 +28,8 @@
     "size": 1426
   },
   "lambdas/update-state/requirements.txt": {
-    "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",
-    "size": 79
+    "shasum": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    "size": 1
   },
   "lambdas/update-state/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -44,8 +44,8 @@
     "size": 7402
   },
   "lambdas/publish/requirements.txt": {
-    "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",
-    "size": 79
+    "shasum": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    "size": 1
   },
   "lambdas/publish/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -64,8 +64,8 @@
     "size": 1403
   },
   "lambdas/api/requirements.txt": {
-    "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",
-    "size": 79
+    "shasum": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    "size": 1
   },
   "lambdas/api/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -76,8 +76,8 @@
     "size": 8124
   },
   "lambdas/feed-rerun/requirements.txt": {
-    "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",
-    "size": 79
+    "shasum": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    "size": 1
   },
   "lambdas/feed-rerun/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -92,8 +92,8 @@
     "size": 2204
   },
   "lambdas/process/requirements.txt": {
-    "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",
-    "size": 79
+    "shasum": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    "size": 1
   },
   "lambdas/process/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -116,8 +116,8 @@
     "size": 0
   },
   "cirrus/lib2/eventdb.py": {
-    "shasum": "a098722cb32ac954dddf6598ecd3eba5d103d711f0f33ffe27d4bbae84e382ab",
-    "size": 7008
+    "shasum": "1cad190973b44fd52f70d2285af7a51746f50c0611f0617fa4d7c8a03fd56ac4",
+    "size": 7003
   },
   "cirrus/lib2/utils.py": {
     "shasum": "2ed2989f8e3f38e5e0e0b72f671cf6ccc9171958c17a2be186293d69bdfb9b8d",

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -116,8 +116,8 @@
     "size": 0
   },
   "cirrus/lib2/eventdb.py": {
-    "shasum": "1cad190973b44fd52f70d2285af7a51746f50c0611f0617fa4d7c8a03fd56ac4",
-    "size": 7003
+    "shasum": "a098722cb32ac954dddf6598ecd3eba5d103d711f0f33ffe27d4bbae84e382ab",
+    "size": 7008
   },
   "cirrus/lib2/utils.py": {
     "shasum": "2ed2989f8e3f38e5e0e0b72f671cf6ccc9171958c17a2be186293d69bdfb9b8d",
@@ -134,33 +134,5 @@
   "cirrus/lib2/process_payload.py": {
     "shasum": "fa8177acf9ec13f089ea4cb15df31f3aa0cf22a3c445176660d9a1822c9c44bc",
     "size": 14073
-  },
-  "cirrus/lib/logging.py": {
-    "shasum": "f578f6385a2270dcee92c2b18d541f4d68dae5950e878193c253f7aa5fedeb0d",
-    "size": 1849
-  },
-  "cirrus/lib/__init__.py": {
-    "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "size": 0
-  },
-  "cirrus/lib/transfer.py": {
-    "shasum": "913a5942e43d500e3c64e302827be85c62dfb17badda801446f92470480bb7e9",
-    "size": 6934
-  },
-  "cirrus/lib/utils.py": {
-    "shasum": "7641e699e1abfdc52890a1c9d684b93eaa260e9234858747170f08559ed7a18d",
-    "size": 5084
-  },
-  "cirrus/lib/errors.py": {
-    "shasum": "15c62d1e8015f09103937c5f400a9814c2d8c2cf01844e0c8e1fcbc49c473e9b",
-    "size": 173
-  },
-  "cirrus/lib/statedb.py": {
-    "shasum": "a4c602b3350fd71ffb70af7efe6aa717c8daa2e0253a56c25e229fe81fb2e117",
-    "size": 19361
-  },
-  "cirrus/lib/process_payload.py": {
-    "shasum": "8465f4256acdac71048b4289e2e104c2d3778a1d445b918c18579542a1fc09b6",
-    "size": 20107
   }
 }


### PR DESCRIPTION
With the archival of `cirrus-lib` it seems reasonable time for the external cirrus-lib package to go now, agreed?