### PR TITLE
improve post-batch error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- In post-batch, better handle errors with the task failing to run and/or the CloudWatch log
+  not existing.
 - Ensure correct count returned from `process` lambda and resolve
   `UnboundLocalError` encountered on certain workflow failures. ([#224])
 

--- a/docs/update-versions.py
+++ b/docs/update-versions.py
@@ -2,7 +2,7 @@
 import sys
 from pathlib import Path
 
-from packaging.version import Version, parse
+from packaging.version import parse
 
 REDIRECT = """<!DOCTYPE html>
 <html>
@@ -29,7 +29,7 @@ def main(gh_pages_dir):
         if _file.is_dir():
             try:
                 version = parse(_file.name)
-            except:
+            except Exception:
                 continue
             version.name = _file.name
             all_versions.add(version.name)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ pre-commit>=2.20.0
 pre-commit-hooks>=4.3.0
 darglint>=1.8.1
 pep8-naming>=0.13.2
+moto[cloudwatch]~=4.2

--- a/src/cirrus/builtins/tasks/post-batch/lambda_function.py
+++ b/src/cirrus/builtins/tasks/post-batch/lambda_function.py
@@ -24,29 +24,52 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         logger.exception(f"Original error: {json.dumps(error)}")
         raise Exception("Unable to get error log: Cause is not defined")
 
-    cause = json.loads(error.get("Cause", {}))
+    cause = json.loads(error.get("Cause", "{}"))
     attempts = cause.get("Attempts", [])
     if not attempts:
         logger.exception(f"Original error: {json.dumps(error)}")
         raise Exception("Unable to get error log: Attempts is empty")
 
-    logname = attempts[-1].get("Container", {}).get("LogStreamName")
+    attempt = attempts[-1]
+    container = attempt.get("Container")
+    if container is None:
+        logger.exception(f"Original error: {json.dumps(error)}")
+        raise Exception(
+            "Unable to get error log: Container for last Attempt is missing"
+        )
+
+    logname = container.get("LogStreamName")
     if not logname:
         logger.exception(f"Original error: {json.dumps(error)}")
         raise Exception(
-            "Unable to get error log: Container or LogStreamName for last Attempt is missing"
+            "Unable to get error log: LogStreamName for last Attempt is missing"
         )
 
+    error_from_batch = None
     try:
-        error_type, error_msg = get_error_from_batch(logname)
+        error_from_batch = get_error_from_batch(logname)
     except Exception as e:
         # lambda does not currently support exeception chaining,
         # so we have to log the original exception separately
-        logger.exception(f"Original error: {json.dumps(error)}")
-        raise Exception(f"Unable to get error log '{BATCH_LOG_GROUP}/{logname}': {e}")
+        logger.exception(
+            f"Unable to get error log '{BATCH_LOG_GROUP}/{logname}' because {e}, original error: {json.dumps(error)}"
+        )
 
-    exception_class = type(error_type, (Exception,), {})
-    raise exception_class(error_msg)
+    if error_from_batch:
+        error_type, error_msg = error_from_batch
+        exception_class = type(error_type, (Exception,), {})
+        raise exception_class(error_msg)
+    else:
+        # if the cloudwatch error log cannot be retrieved, it's likely that the container
+        # didn't start and nothing was logged anyway, so we log the reason for that instead
+        container_reason = container.get(
+            "Reason"
+        )  # e.g., "DockerTimeoutError: Could not transition to created; timed out after waiting 4m0s"
+        status_reason = attempt.get("StatusReason")  # e.g., "Task failed to start"
+        raise Exception(
+            "Unable to get error log, container likely never ran. "
+            f"Container Reason: {container_reason}; Status Reason: {status_reason}"
+        )
 
 
 def get_error_from_batch(logname: str) -> Optional[Tuple[str, str]]:

--- a/src/cirrus/builtins/tasks/post-batch/lambda_function.py
+++ b/src/cirrus/builtins/tasks/post-batch/lambda_function.py
@@ -1,5 +1,6 @@
 import json
 import re
+from typing import Any, Optional, Tuple
 
 import boto3
 
@@ -14,27 +15,41 @@ DEFAULT_ERROR = "UnknownError"
 ERROR_REGEX = re.compile(r"^(?:cirrus\.?lib\.errors\.)?(?:([\.\w]+):)?\s*(.*)")
 
 
-def lambda_handler(event, context):
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     if "error" not in event:
         return ProcessPayload.from_event(event).get_payload()
 
     error = event.get("error", {})
-    cause = json.loads(error["Cause"])
-    logname = cause["Attempts"][-1]["Container"]["LogStreamName"]
+    if "Cause" not in error:
+        logger.exception(f"Original error: {json.dumps(error)}")
+        raise Exception("Unable to get error log: Cause is not defined")
+
+    cause = json.loads(error.get("Cause", {}))
+    attempts = cause.get("Attempts", [])
+    if not attempts:
+        logger.exception(f"Original error: {json.dumps(error)}")
+        raise Exception("Unable to get error log: Attempts is empty")
+
+    logname = attempts[-1].get("Container", {}).get("LogStreamName")
+    if not logname:
+        logger.exception(f"Original error: {json.dumps(error)}")
+        raise Exception(
+            "Unable to get error log: Container or LogStreamName for last Attempt is missing"
+        )
 
     try:
         error_type, error_msg = get_error_from_batch(logname)
-    except Exception:
+    except Exception as e:
         # lambda does not currently support exeception chaining,
         # so we have to log the original exception separately
-        logger.exception("Original exception:")
-        raise Exception("Unable to get error log")
+        logger.exception(f"Original error: {json.dumps(error)}")
+        raise Exception(f"Unable to get error log '{BATCH_LOG_GROUP}/{logname}': {e}")
 
     exception_class = type(error_type, (Exception,), {})
     raise exception_class(error_msg)
 
 
-def get_error_from_batch(logname):
+def get_error_from_batch(logname: str) -> Optional[Tuple[str, str]]:
     logger.info("Getting error from %s/%s", BATCH_LOG_GROUP, logname)
     logs = LOG_CLIENT.get_log_events(
         logGroupName=BATCH_LOG_GROUP,

--- a/src/cirrus/builtins/tasks/pre-batch/lambda_function.py
+++ b/src/cirrus/builtins/tasks/pre-batch/lambda_function.py
@@ -22,10 +22,7 @@ def lambda_handler(event, context):
         s3().upload_json(payload, url)
 
         logger.debug(f"Uploaded payload to {url}")
-        return {
-            "url": url,
-            "url_out": url_out
-        }
+        return {"url": url, "url_out": url_out}
     except Exception as err:
         msg = f"pre-batch: failed pre processing batch job for ({err})"
         logger.error(msg, exc_info=True)

--- a/tests/builtins/tasks/test_post_batch.py
+++ b/tests/builtins/tasks/test_post_batch.py
@@ -1,4 +1,7 @@
+import json
+
 import pytest
+from moto import mock_logs
 
 from cirrus.test import run_task
 
@@ -6,3 +9,87 @@ from cirrus.test import run_task
 def test_empty_event():
     with pytest.raises(Exception):
         run_task("post-batch", {})
+
+
+@mock_logs
+def test_error_handling():
+    with pytest.raises(
+        Exception, match=r"Unable to get error log: Cause is not defined"
+    ):
+        run_task("post-batch", {"error": {}})
+
+    with pytest.raises(Exception, match=r"Unable to get error log: Attempts is empty"):
+        run_task("post-batch", {"error": {"Cause": "{}"}})
+
+    with pytest.raises(Exception, match=r"Unable to get error log: Attempts is empty"):
+        run_task("post-batch", {"error": {"Cause": json.dumps({"Attempts": []})}})
+
+    with pytest.raises(
+        Exception,
+        match=r"Unable to get error log: Container for last Attempt is missing",
+    ):
+        run_task("post-batch", {"error": {"Cause": json.dumps({"Attempts": [{}]})}})
+
+    with pytest.raises(
+        Exception,
+        match=r"Unable to get error log: LogStreamName for last Attempt is missing",
+    ):
+        run_task(
+            "post-batch",
+            {"error": {"Cause": json.dumps({"Attempts": [{"Container": {}}]})}},
+        )
+
+    with pytest.raises(
+        Exception,
+        match=r"Unable to get error log: LogStreamName for last Attempt is missing",
+    ):
+        run_task(
+            "post-batch",
+            {
+                "error": {
+                    "Cause": json.dumps(
+                        {"Attempts": [{"Container": {"LogStreamName": ""}}]}
+                    )
+                }
+            },
+        )
+
+    with pytest.raises(
+        Exception,
+        match=r"Unable to get error log, container likely never ran. Container Reason: None; Status Reason: None",
+    ):
+        run_task(
+            "post-batch",
+            {
+                "error": {
+                    "Cause": json.dumps(
+                        {"Attempts": [{"Container": {"LogStreamName": "foobar"}}]}
+                    )
+                }
+            },
+        )
+
+    with pytest.raises(
+        Exception,
+        match=r"Unable to get error log, container likely never ran. Container Reason: DockerTimeoutError: Could not transition to created; timed out after waiting 4m0s; Status Reason: Task failed to start",
+    ):
+        run_task(
+            "post-batch",
+            {
+                "error": {
+                    "Cause": json.dumps(
+                        {
+                            "Attempts": [
+                                {
+                                    "Container": {
+                                        "LogStreamName": "cirrus-es-prod-Sentinel2/default/a6768fc4fce04b809905ff65e71a9b38",
+                                        "Reason": "DockerTimeoutError: Could not transition to created; timed out after waiting 4m0s",
+                                    },
+                                    "StatusReason": "Task failed to start",
+                                }
+                            ]
+                        }
+                    )
+                }
+            },
+        )

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -12,8 +12,8 @@
     "size": 0
   },
   "lambdas/pre-batch/lambda_function.py": {
-    "shasum": "0f4338592635f867c910ccecefe7a6a42de80bed8274a88a9a699c469ec83317",
-    "size": 892
+    "shasum": "e3d90e2f50032e65eb651c4290ea35bf97e6951eca5fe2391fa00e720ee2ee2a",
+    "size": 858
   },
   "lambdas/post-batch/requirements.txt": {
     "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",
@@ -24,8 +24,8 @@
     "size": 0
   },
   "lambdas/post-batch/lambda_function.py": {
-    "shasum": "5c0ee9914f5ac42f63f8b5fe49301408f50135f45529b98bb56e4f1a957a5ba8",
-    "size": 1426
+    "shasum": "c2241a4af118dd4ad615fff80e1a50caf23fa104c50fdb81788fef6093bb047e",
+    "size": 2188
   },
   "lambdas/update-state/requirements.txt": {
     "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -24,8 +24,8 @@
     "size": 0
   },
   "lambdas/post-batch/lambda_function.py": {
-    "shasum": "c2241a4af118dd4ad615fff80e1a50caf23fa104c50fdb81788fef6093bb047e",
-    "size": 2188
+    "shasum": "7cca6f45a7a8b3885ea7d852cd59b9c1f56c6a2e4ff8c885f13a7066ca054f4d",
+    "size": 3161
   },
   "lambdas/update-state/requirements.txt": {
     "shasum": "f1962dc2c6c8cc51c7eabb23eb0abf666063167b7609e16fe504971aa663b908",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -142,7 +142,7 @@ def test_build(invoke, project, reference_build, build_dir):
             f"Test build directory: {build_dir}\n"
             "\n"
             "If all highlighted changes are expected, simply remove \n"
-            "the reference_build directory and rerun the tests to update \n"
+            "the 'Reference build' directory and rerun the tests to update \n"
             "the reference files."
         )
 


### PR DESCRIPTION
Resolves a few issues:

1. If the job was never tried, there's no `Attempts` array, which throws:
```
"Cause": "{\"errorMessage\": \"list index out of range\", \"errorType\": \"IndexError\", \"requestId\": \"e0980b7b-27f9-4501-a7f0-c99e76fd81c3\", \"stackTrace\": [\"  File \\\"/var/task/lambda_function.py\\\", line 23, in lambda_handler\\n    logname = cause[\\\"Attempts\\\"][-1][\\\"Container\\\"][\\\"LogStreamName\\\"]\\n\"]}"
```

2. Failure to retrieve the cloudwatch logstream (which will happen if the stream was named but never logged to, so it doesn't exist) used `logger.exception("Original exception:")` missing the actual original *error* message, and the dynamodb failure message is just "Exception: Unable to get error log.". This now logs the Reason instead, which is typically due to a failure to run the Batch task at all.

3. Better handling for other cases where the message is incomplete.