### PR TITLE
restore InvalidInput exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Restore `InvalidInput` exception, which only existed in `cirrus-lib` (and
-  `stactask`). ([#255])
+  `stactask`). ([#256])
 
 ## [v0.12.0] - 2024-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Restore `InvalidInput` exception, which only existed in `cirrus-lib` (and
+  `stactask`). ([#255])
+
 ## [v0.12.0] - 2024-02-14
 
 ### Fixed

--- a/src/cirrus/lib2/errors.py
+++ b/src/cirrus/lib2/errors.py
@@ -2,3 +2,9 @@ class NoUrlError(ValueError):
     """Exception class for when a payload does not have a URL."""
 
     pass
+
+
+class InvalidInput(Exception):  # noqa: N818
+    """Exception class for when processing fails due to invalid input."""
+
+    pass

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -124,8 +124,8 @@
     "size": 8974
   },
   "cirrus/lib2/errors.py": {
-    "shasum": "2f6699dd2f40f4ac17fcf7438efe7b0716604752a76dbb19c100778c322dd129",
-    "size": 106
+    "shasum": "94ff1e0410118c41269067a37f3eeae6fd040fa5c727e054ebcb7df1a4583a59",
+    "size": 237
   },
   "cirrus/lib2/statedb.py": {
     "shasum": "524fd07227f1ae91fb850944aded93491c5849b315f495c59c8dfec3a15e45f7",


### PR DESCRIPTION
This exception is still used and referenced in the docs, but worked with `cirrus-lib` (or stactask (see #180)) by using the string to triage INVALID_EXCEPTIONS.  With the purge of `cirrus-lib`, this brings that exception back to cirrus-geo.