### PR TITLE
updates for v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.12.1] - 2024-02-15
 
 ### Fixed
 
@@ -708,6 +708,7 @@ Initial release
 
 <!-- [unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.11.3...main -->
 
+[v0.12.1]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.12.0...v0.12.1
 [v0.12.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.11.4...v0.12.0
 [v0.11.4]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.11.3...v0.11.4
 [v0.11.3]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.11.2...v0.11.3


### PR DESCRIPTION
### Fixed

- Restore `InvalidInput` exception, which only existed in `cirrus-lib` (and
  `stactask`). ([#256])
