### PR TITLE
stop propagation of messages after cirrus loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Prevent `cirrus.lib2.logging` logger messages from being duplicated by the
+  root logger. ([#264])
+
 ## [v0.13.0] - 2024-03-04
 
 ### Added
@@ -846,6 +853,7 @@ Initial release
 [#254]: https://github.com/cirrus-geo/cirrus-geo/pull/254
 [#256]: https://github.com/cirrus-geo/cirrus-geo/pull/256
 [#259]: https://github.com/cirrus-geo/cirrus-geo/pull/259
+[#264]: https://github.com/cirrus-geo/cirrus-geo/pull/264
 [f25acd4]: https://github.com/cirrus-geo/cirrus-geo/commit/f25acd4f43e2d8e766ff8b2c3c5a54606b1746f2
 [85464f5]: https://github.com/cirrus-geo/cirrus-geo/commit/85464f5a7cb3ef82bc93f6f1314e98b4af6ff6c1
 [1b89611]: https://github.com/cirrus-geo/cirrus-geo/commit/1b89611125e2fa852554951343731d1682dd3c4c

--- a/src/cirrus/lib2/logging.py
+++ b/src/cirrus/lib2/logging.py
@@ -49,6 +49,9 @@ class DynamicLoggerAdapter(logging.LoggerAdapter):
     def __init__(self, *args, keys=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.keys = keys
+        if self.logger.parent and self.logger.parent.name in config["loggers"]:
+            # this prevents double-logging in AWS Cloudwatch for cirrus loggers
+            self.logger.parent.propagate = False
 
     def process(self, msg, kwargs):
         if self.keys is not None:

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -108,8 +108,8 @@
     "size": 2627
   },
   "cirrus/lib2/logging.py": {
-    "shasum": "bee855ad35595b58e26bb094e0e516eed2e98337a4817d6543e7d49e7cfa8a97",
-    "size": 2700
+    "shasum": "eccfdad4b87f655ea68fb993bd29067116aeb6e2043f2edeb17034fd5d4d895b",
+    "size": 2909
   },
   "cirrus/lib2/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",


### PR DESCRIPTION
There may be a case against this, but this stops cirrus loggers from doubling messages in Cloudwatch.