### PR TITLE
Remove `ProcessPayload.assign_collections` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v0.14.0] - 2024-04-26
+
 ### Changed
 
 - Prevent `cirrus.lib2.logging` logger messages from being duplicated by the
@@ -754,7 +756,8 @@ cleanup steps.
 
 Initial release
 
-[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.12.1...main
+[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.14.0...main
+[v0.14.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.13.0...v0.14.0
 [v0.13.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.12.1...v0.13.0
 [v0.12.1]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.12.0...v0.12.1
 [v0.12.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.11.4...v0.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Prevent `cirrus.lib2.logging` logger messages from being duplicated by the
   root logger. ([#264])
+- Collections are not assigned by any of the built-in functions or tasks. ([#266])
+
+### Removed
+
+- `ProcessPayload.assign_collections()` removed in favor of having tasks assign
+  collections to items themselves (which happens automatically when using
+  stac-task. ([#266])
 
 ## [v0.13.0] - 2024-03-04
 
@@ -854,6 +861,7 @@ Initial release
 [#256]: https://github.com/cirrus-geo/cirrus-geo/pull/256
 [#259]: https://github.com/cirrus-geo/cirrus-geo/pull/259
 [#264]: https://github.com/cirrus-geo/cirrus-geo/pull/264
+[#266]: https://github.com/cirrus-geo/cirrus-geo/pull/266
 [f25acd4]: https://github.com/cirrus-geo/cirrus-geo/commit/f25acd4f43e2d8e766ff8b2c3c5a54606b1746f2
 [85464f5]: https://github.com/cirrus-geo/cirrus-geo/commit/85464f5a7cb3ef82bc93f6f1314e98b4af6ff6c1
 [1b89611]: https://github.com/cirrus-geo/cirrus-geo/commit/1b89611125e2fa852554951343731d1682dd3c4c

--- a/src/cirrus/lib2/process_payload.py
+++ b/src/cirrus/lib2/process_payload.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 import uuid
 import warnings
 from copy import deepcopy
@@ -106,9 +105,6 @@ class ProcessPayload(dict):
             if "links" not in item:
                 item["links"] = []
 
-        # update collection IDs of member Items
-        self.assign_collections()
-
         self.state_item = state_item
 
     @classmethod
@@ -186,22 +182,6 @@ class ProcessPayload(dict):
             "id"
         ] = f"{collections_str}/workflow-{self.process['workflow']}/{items_str}"
 
-    # assign collections to Items given a mapping of Col ID: ID regex
-    def assign_collections(self):
-        """Assign new collections to all Items (features) in ProcessPayload
-        based on self.process['upload_options']['collections']
-        """
-        collections = self.process["upload_options"].get("collections", {})
-        # loop through all Items in ProcessPayload
-        for item in self.features:
-            # loop through all provided output collections regexs
-            for col in collections:
-                regex = re.compile(collections[col])
-                if regex.match(item["id"]):
-                    self.logger.debug(f"Setting collection to {col}")
-                    item["collection"] = col
-                    break
-
     def get_payload(self) -> dict:
         """Get original payload for this ProcessPayload
 
@@ -217,7 +197,7 @@ class ProcessPayload(dict):
         else:
             return dict(self)
 
-    def __call__(self) -> str:
+    def __call__(self) -> str | None:
         """Add this ProcessPayload to Cirrus and start workflow
 
         Returns:

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -132,7 +132,7 @@
     "size": 22034
   },
   "cirrus/lib2/process_payload.py": {
-    "shasum": "901c682441e87446ef13456d4daceec73bd315be3bab1ea275c7bfb36e1dff76",
-    "size": 14099
+    "shasum": "edc29ac893962b82cf8f05b9d1b40152ceed9aaf1250bb03d72d46734d2af744",
+    "size": 13255
   }
 }

--- a/tests/lib/test_process_payload.py
+++ b/tests/lib/test_process_payload.py
@@ -99,13 +99,6 @@ def test_from_event(sqs_event):
     )
 
 
-def test_assign_collections(base_payload):
-    payload = ProcessPayload(base_payload)
-    payload["process"]["upload_options"]["collections"] = {"test": ".*"}
-    payload.assign_collections()
-    assert payload["features"][0]["collection"] == "test"
-
-
 def test_next_payloads_no_list(base_payload):
     payloads = list(ProcessPayload.from_event(base_payload).next_payloads())
     assert len(payloads) == 0


### PR DESCRIPTION
`ProcessPayload.assign_collections` uses a different format (regex vs jsonpath) than the equivalent stac-task. Rather than standardizing on the stac-task implementation, we have decided to remove this method altogether and expect tasks will assign collections as appropriate (which is done automatically when using stac-task).

Related issue: https://github.com/cirrus-geo/cirrus-geo/issues/227.