### PR TITLE
added function 'cirrus.lib2.utils.cold_start'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `payload_id` was not passed properly to `StateDB` for logging, via the state
   change decorator. Updated the decorator to be a Descriptor, which may make
   type checking happier. ([#270])
+- added function `cirrus.lib2.utils.cold_start` to move overhead of boto
+  client/resource cache instantiation out of lambda function execution. ([#272])
 
 ### Added
 
@@ -926,6 +928,7 @@ Initial release
 [#266]: https://github.com/cirrus-geo/cirrus-geo/pull/266
 [#267]: https://github.com/cirrus-geo/cirrus-geo/pull/267
 [#270]: https://github.com/cirrus-geo/cirrus-geo/pull/270
+[#272]: https://github.com/cirrus-geo/cirrus-geo/pull/272
 [f25acd4]: https://github.com/cirrus-geo/cirrus-geo/commit/f25acd4f43e2d8e766ff8b2c3c5a54606b1746f2
 [85464f5]: https://github.com/cirrus-geo/cirrus-geo/commit/85464f5a7cb3ef82bc93f6f1314e98b4af6ff6c1
 [1b89611]: https://github.com/cirrus-geo/cirrus-geo/commit/1b89611125e2fa852554951343731d1682dd3c4c

--- a/src/cirrus/builtins/functions/process/lambda_function.py
+++ b/src/cirrus/builtins/functions/process/lambda_function.py
@@ -8,6 +8,8 @@ from cirrus.lib2.logging import defer, get_task_logger
 from cirrus.lib2.process_payload import ProcessPayload, ProcessPayloads
 from cirrus.lib2.statedb import StateDB
 
+utils.cold_start()
+
 logger = get_task_logger("function.process", payload=tuple())
 
 

--- a/src/cirrus/builtins/functions/update-state/lambda_function.py
+++ b/src/cirrus/builtins/functions/update-state/lambda_function.py
@@ -9,7 +9,9 @@ from cirrus.lib2.events import WorkflowEventManager
 from cirrus.lib2.logging import get_task_logger
 from cirrus.lib2.process_payload import ProcessPayload
 from cirrus.lib2.statedb import StateDB
-from cirrus.lib2.utils import SNSPublisher, SQSPublisher, get_client
+from cirrus.lib2.utils import SNSPublisher, SQSPublisher, cold_start, get_client
+
+cold_start()
 
 logger = get_task_logger("function.update-state", payload=tuple())
 

--- a/src/cirrus/lib2/utils.py
+++ b/src/cirrus/lib2/utils.py
@@ -35,6 +35,27 @@ def execution_url(execution_arn: str, region: Optional[str] = None) -> str:
     )
 
 
+def cold_start(
+    clients=(
+        "batch",
+        "s3",
+        "sns",
+        "sqs",
+        "stepfunctions",
+        "timestream-query",
+        "timestream-write",
+    ),
+    resources=("dynamodb", "sqs"),
+):
+    """Used in lambda functions to populate the cache of boto clients/resoures.  Default
+    values cover core cirrus usages."""
+    for client in clients:
+        get_client(client)
+
+    for resource in resources:
+        get_resource(resource)
+
+
 @cache
 def get_client(service: str, session: Optional[boto3.Session] = None):
     """Wrapper around boto3 which implements singleton pattern via @cache"""

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -40,8 +40,8 @@
     "size": 83
   },
   "lambdas/update-state/lambda_function.py": {
-    "shasum": "58df7e132110c09121a8ef18c372176578f0402ebe4904572f94adb507a1a1de",
-    "size": 7780
+    "shasum": "8b790fe4905b02310248813b685374b6bfc2dfdac62ad19f7213eb6b15d86c96",
+    "size": 7806
   },
   "lambdas/publish/requirements.txt": {
     "shasum": "e5f05c7df535c6dfb7c9eab53bbb4bdebea7ee03f1894c58410795dfcb398538",
@@ -104,8 +104,8 @@
     "size": 26
   },
   "lambdas/process/lambda_function.py": {
-    "shasum": "00e190c1a667495225983c94f6762dfc4b161272b7b91483a7f17bea571cf7f0",
-    "size": 3616
+    "shasum": "93a5e192e6e305338bac7af5c12f331010a634b14c24da57c0fae60fdc6f11a3",
+    "size": 3636
   },
   "cirrus/lib2/logging.py": {
     "shasum": "eccfdad4b87f655ea68fb993bd29067116aeb6e2043f2edeb17034fd5d4d895b",
@@ -128,8 +128,8 @@
     "size": 6245
   },
   "cirrus/lib2/utils.py": {
-    "shasum": "b7e38592ed39ce32f9650b78f96c75f91e0b5a4f43972c872a8f29f6492a70c5",
-    "size": 14818
+    "shasum": "d50ea09a6cf1a0dce42ff3bef673cbac4adf836b3cf31422cce28a3a11f7067c",
+    "size": 15283
   },
   "cirrus/lib2/errors.py": {
     "shasum": "94ff1e0410118c41269067a37f3eeae6fd040fa5c727e054ebcb7df1a4583a59",


### PR DESCRIPTION
Moves boto3 client/resource instantiation out of the invocation of the core cirrus lambdas.