### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.15.0] - 2024-05-06
 
 ### ⚠️ Deprecations
 
@@ -37,16 +37,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
     ```yaml
     CIRRUS_WORKFLOW_EVENT_TOPIC_ARN: !Ref WorkflowEventTopic
-    ```
-
-    and add the Topic to their `cloudformation/resources.yml` file:
-
-    ```yaml
-    # SNS Topic for any cirrus interactions with a workflow
-    WorkflowEventTopic:
-      Type: "AWS::SNS::Topic"
-      Properties:
-      TopicName: "#{AWS::StackName}-workflow-event"
     ```
 
 - Testing of python 3.12. ([#261])
@@ -814,7 +804,8 @@ cleanup steps.
 
 Initial release
 
-[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.14.0...main
+[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.0...main
+[v0.15.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.14.0...v0.15.0
 [v0.14.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.13.0...v0.14.0
 [v0.13.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.12.1...v0.13.0
 [v0.12.1]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.12.0...v0.12.1


### PR DESCRIPTION
### ⚠️ Deprecations

- Both the `CIRRUS_FAILED_TOPIC_ARN` and `CIRRUS_INVALID_TOPIC_ARN` SNS Topics
  have been deprecated, and the `CIRRUS_WORKFLOW_EVENT_TOPIC_ARN` Topic should
  be used by subscriptions which need to act on failed or invalid workflows.

### Fixed

- Incorrect function `already_processing` corrected to
  `skipping(state="PROCESSING",...)`. ([#267])
- `payload_id` was not passed properly to `StateDB` for logging, via the state
  change decorator. Updated the decorator to be a Descriptor, which may make
  type checking happier. ([#270])
- added function `cirrus.lib2.utils.cold_start` to move overhead of boto
  client/resource cache instantiation out of lambda function execution. ([#272])

### Added

- `cirrus-<stage>-workflow-event` SNS topic, and
  `WorkflowEventManager` class for managing workflow event actions. ([#261])
  The actions managed by this class include:

  - updating state of workflows in `StateDB`
  - announcing interactions cirrus has with a payload to the
    `cirrus-<stage>-workflow-event`
    Note: To use this topic, existing deployments will need to add the following
    to their environment in both their `cirrus.yml` file:

    ```yaml
    CIRRUS_WORKFLOW_EVENT_TOPIC_ARN: !Ref WorkflowEventTopic
    ```

    and add the Topic to their `cloudformation/resources.yml` file:

    ```yaml
    # SNS Topic for any cirrus interactions with a workflow
    WorkflowEventTopic:
      Type: "AWS::SNS::Topic"
      Properties:
      TopicName: "#{AWS::StackName}-workflow-event"
    ```

- Testing of python 3.12. ([#261])
- `SfnStatus` string enum added for StepFunctions execution status
  strings. ([#261])
- Added check of status returned from AWS calls to update the `StateDB` table,
  which raises a `RuntimeError` including the response if the write fails.
  This addresses Issue [#202]. ([#263])

### Changed

- Moved `StateEnum` to `cirrus.lib2.enums` module for use across `lib2` and
  `builtins`. ([#261])
- Migrated management of timeseries (`EventDB`) events from `StateDB` to
  `WorkflowEventManager`. ([#263])
- Provide option to pass in timestamp to `WorkflowEventManager` state-change
  functions. ([#263])
    