### PR TITLE
Release v0.15.1: fixing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.15.1] - 2024-05-09
 
 ### Fixed
 
@@ -810,7 +810,8 @@ cleanup steps.
 
 Initial release
 
-[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.0...main
+[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.0...release/v0
+[v0.15.1]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.0...v0.15.1
 [v0.15.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.14.0...v0.15.0
 [v0.14.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.13.0...v0.14.0
 [v0.13.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.12.1...v0.13.0


### PR DESCRIPTION
### Fixed

- Stop `SNSPublisher` and `SQSPublisher` from overwriting `dest_name`. ([#274])

