### PR TITLE
Build a dist zip for all cirrus lambdas

### DIFF
--- a/.github/workflows/build-lambda-dist.yml
+++ b/.github/workflows/build-lambda-dist.yml
@@ -1,0 +1,33 @@
+name: Build lambda dist zip
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  build-lambda-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install '.'
+      - name: Build lambda zip
+        run: ./bin/build-lambda-dist.bash
+      - name: Add to release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: cirrus-lambda-dist.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cirrus-lambda-dist.zip
 output/
 .DS_Store
 

--- a/bin/build-lambda-dist.bash
+++ b/bin/build-lambda-dist.bash
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+CIRRUS_LAMBDA_ZIP="./cirrus-lambda-dist.zip"
+
+
+find_this () {
+    THIS="${1:?'must provide script path, like "${BASH_SOURCE[0]}" or "$0"'}"
+    trap "echo >&2 'FATAL: could not resolve parent directory of ${THIS}'" EXIT
+    [ "${THIS:0:1}"  == "/" ] || THIS="$(pwd -P)/${THIS}"
+    THIS_DIR="$(dirname -- "${THIS}")"
+    THIS_DIR="$(cd -P -- "${THIS_DIR}" && pwd)"
+    THIS="${THIS_DIR}/$(basename -- "${THIS}")"
+    trap "" EXIT
+}
+
+
+setup_venv() {
+    local venv
+    venv="${1:-'provide path to directory for venv'}"
+    python -m venv "${venv}"
+    "${venv}/bin/pip" install "${THIS_DIR}"/..
+}
+
+
+make_zip_base() {
+    local venv dest _python site_packages
+    venv="${1:-'provide path to virtual env with cirrus installed'}"
+    dest="${2:-'provide path to output zip file'}"
+    _python="${venv}/bin/python"
+    site_packages="$("${_python}" -c "import sysconfig as s; print(s.get_path('purelib'))")"
+    (
+        cd "${site_packages}"
+        zip -r "${dest}" .
+        # we don't need or want pip cluttering up our lambda zip
+        zip --delete "${dest}" 'pip/*'
+    )
+}
+
+
+get_lambda_handlers() {
+    local venv
+    venv="${1:-'provide path to virtual env with cirrus installed'}"
+    "${venv}/bin/python" <<EOP
+from pathlib import Path
+from cirrus import lambda_functions
+
+reader = lambda_functions.__loader__.get_resource_reader()
+
+for path in map(lambda x: reader.path / Path(x), reader.contents()):
+    if path.suffix not in ('.py', '.pyc'):
+        continue
+    if path.stem == '__init__':
+        continue
+
+    print(path)
+EOP
+}
+
+
+main() {
+    find_this "${BASH_SOURCE[0]}"
+
+    local zipfile venv handler lambda_name tmp_zip
+
+    zipfile="$(mktemp -u)"
+    (
+        trap "rm -f '${zipfile}'" EXIT
+
+        venv="$(mktemp -d)"
+        (
+            trap "rm -rf '${venv}'" EXIT
+
+            setup_venv "${venv}"
+            make_zip_base "${venv}" "${zipfile}"
+            get_lambda_handlers "${venv}" | while IFS= read -r handler; do
+                (
+                    cd "$(dirname "${handler}")"
+                    zip "${zipfile}" "$(basename "${handler}")"
+                )
+            done
+        )
+
+        mv "${zipfile}" "${CIRRUS_LAMBDA_ZIP}"
+        trap "" EXIT
+    )
+}
+
+
+main "$@"


### PR DESCRIPTION
Allows downstream users to already have a packaged zip file they can use for deployments. Also provides a build script that can be run or used for reference if users want to package the lambdas themselves.

An included github action workflow will package on all PRs and merges to main to ensure the script executes successfully. Release publishing will run the workflow and put the produced zip as an artifact on the release, allowing users to fetch that zip for a targeted cirrus release version.