### PR TITLE
Fix package build and switch to trusted publishers

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,13 +1,24 @@
-name: Upload Python Package
+name: Build Python Package
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   release:
-    types: [published]
+    types:
+      - published
 
 jobs:
-  deploy:
+  build-package:
     runs-on: ubuntu-latest
-
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cirrus-geo
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -17,12 +28,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-      - name: Build and publish
-        env:
-          CIRRUS_VERSION: ${{ github.event.release.tag_name }}
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_APIKEY }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/*
+          pip install build
+          pip install .
+      - name: Build package
+        run: python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
The github actions workflow for publishing a new package version to pypi broke with the v1 refactor and modernization to pyproject.toml. This PR fixes that release workflow, changes it to run on all pushes to PRs and main (without the publish, to check that the package builds), and switches to trusted publishers rather than using my API key (thank goodness).