### PR TITLE
update rich & python-dateutil and clean up python requirement packaging (v0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   collection is specified neither via `payload.collections` nor on the items in
   `payload.features[].collection`. ([#279])
 
+### Changed
+
+- Loosened requirement `rich~=10.6` to `rich`, and bumped python-dateutil from
+  `~2.8.2` to `~2.9.0`. Note, the sum total of `rich` usage is printing
+  escaped character sequences to the console.
+
 ## [v0.15.1] - 2024-05-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed issue [#225] where default string is treated as a list when input
   collection is specified neither via `payload.collections` nor on the items in
   `payload.features[].collection`. ([#279])
+- Fixed issue [#255] for the `release/v0` branch by using a heuristic to select
+  only the libs that cirrus.lib2 needs for injection into the python lambda
+  requirements files. ([#283])
 
 ### Changed
 
 - Loosened requirement `rich~=10.6` to `rich`, and bumped python-dateutil from
   `~2.8.2` to `~2.9.0`. Note, the sum total of `rich` usage is printing
-  escaped character sequences to the console.
+  escaped character sequences to the console. ([#283])
+
+### Removed
+
+- Removed slimPatterns for `boto*` and `dateutil` packages, per [#242]. ([#283])
 
 ## [v0.15.1] - 2024-05-09
 
@@ -911,6 +918,8 @@ Initial release
 [#193]: https://github.com/cirrus-geo/cirrus-geo/issues/193
 [#202]: https://github.com/cirrus-geo/cirrus-geo/issues/202
 [#225]: https://github.com/cirrus-geo/cirrus-geo/issues/225
+[#242]: https://github.com/cirrus-geo/cirrus-geo/issues/242
+[#255]: https://github.com/cirrus-geo/cirrus-geo/issues/255
 [#71]: https://github.com/cirrus-geo/cirrus-geo/pull/72
 [#72]: https://github.com/cirrus-geo/cirrus-geo/pull/72
 [#73]: https://github.com/cirrus-geo/cirrus-geo/pull/73
@@ -944,6 +953,7 @@ Initial release
 [#272]: https://github.com/cirrus-geo/cirrus-geo/pull/272
 [#274]: https://github.com/cirrus-geo/cirrus-geo/pull/274
 [#279]: https://github.com/cirrus-geo/cirrus-geo/pull/279
+[#283]: https://github.com/cirrus-geo/cirrus-geo/pull/283
 [f25acd4]: https://github.com/cirrus-geo/cirrus-geo/commit/f25acd4f43e2d8e766ff8b2c3c5a54606b1746f2
 [85464f5]: https://github.com/cirrus-geo/cirrus-geo/commit/85464f5a7cb3ef82bc93f6f1314e98b4af6ff6c1
 [1b89611]: https://github.com/cirrus-geo/cirrus-geo/commit/1b89611125e2fa852554951343731d1682dd3c4c

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 pyyaml~=6.0
 click~=8.0
 click-plugins~=1.1
-rich~=10.6
+rich
 cfn-flip~=1.2
 boto3-utils~=0.4.1
 boto3>=1.26.0
 python-json-logger~=2.0
 jsonpath-ng>=1.5.3
-python-dateutil~=2.8.2
+python-dateutil~=2.9.0

--- a/src/cirrus/core/config/__init__.py
+++ b/src/cirrus/core/config/__init__.py
@@ -46,7 +46,7 @@ class Config(NamedYamlable):
         if "include" not in self.custom.pythonRequirements:
             self.custom.pythonRequirements.include = []
         self.custom.pythonRequirements.include.extend(
-            misc.get_cirrus_geo_requirements(),
+            misc.get_cirrus_geo_lib2_requirements(),
         )
 
         # populate required plugin list

--- a/src/cirrus/core/config/default.yml
+++ b/src/cirrus/core/config/default.yml
@@ -44,12 +44,7 @@ custom:
     slim: true
     slimPatternsAppendDefaults: false
     slimPatterns:
-      - "botocore/**"
-      - "botocore-*/**"
-      - "boto3/**"
-      - "boto3-*/**"
       - "bin/**"
-      - "dateutils*"
       - "docutils/**"
       - "docutils-*/**"
       - "numpy/**"

--- a/src/cirrus/core/utils/misc.py
+++ b/src/cirrus/core/utils/misc.py
@@ -4,13 +4,21 @@ from importlib import metadata
 from pathlib import Path
 
 
-def get_cirrus_geo_requirements() -> list[str]:
+def get_cirrus_geo_lib2_requirements() -> list[str]:
     """
-    Get the cirrus-geo dependencies.
+    Get the cirrus-geo lib2 dependencies, for injection into deployed lambdas.
     """
-    return [
+    full_reqs = [
         req.split(";")[0].translate(str.maketrans("", "", " ()"))
         for req in metadata.requires("cirrus-geo")
+    ]
+    return [
+        lib_req
+        for lib_req in full_reqs
+        if not any(
+            lib_req.startswith(main_req)
+            for main_req in ("pyyaml", "click", "click-plugins", "rich", "cfn-flip")
+        )
     ]
 
 

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -1,11 +1,11 @@
 {
   "serverless.yml": {
-    "shasum": "1e0c3e44eefea234949ee6a0ffe51d68e36f111ff0298b412197ee6fe19272c7",
-    "size": 40310
+    "shasum": "d1909875e0417d277268b86367439b0770f4b1332497b85e1408a7cf85c7099d",
+    "size": 40213
   },
   "lambdas/pre-batch/requirements.txt": {
-    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
-    "size": 160
+    "shasum": "eb5f4e337f4a9a7616308c5314fc75c3f62a59ce921c012d1a1281038bdbbfd1",
+    "size": 99
   },
   "lambdas/pre-batch/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -16,8 +16,8 @@
     "size": 858
   },
   "lambdas/post-batch/requirements.txt": {
-    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
-    "size": 160
+    "shasum": "eb5f4e337f4a9a7616308c5314fc75c3f62a59ce921c012d1a1281038bdbbfd1",
+    "size": 99
   },
   "lambdas/post-batch/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -28,8 +28,8 @@
     "size": 3161
   },
   "lambdas/update-state/requirements.txt": {
-    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
-    "size": 160
+    "shasum": "eb5f4e337f4a9a7616308c5314fc75c3f62a59ce921c012d1a1281038bdbbfd1",
+    "size": 99
   },
   "lambdas/update-state/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -44,8 +44,8 @@
     "size": 7806
   },
   "lambdas/publish/requirements.txt": {
-    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
-    "size": 160
+    "shasum": "eb5f4e337f4a9a7616308c5314fc75c3f62a59ce921c012d1a1281038bdbbfd1",
+    "size": 99
   },
   "lambdas/publish/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -64,8 +64,8 @@
     "size": 1403
   },
   "lambdas/api/requirements.txt": {
-    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
-    "size": 160
+    "shasum": "eb5f4e337f4a9a7616308c5314fc75c3f62a59ce921c012d1a1281038bdbbfd1",
+    "size": 99
   },
   "lambdas/api/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -76,8 +76,8 @@
     "size": 8162
   },
   "lambdas/feed-rerun/requirements.txt": {
-    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
-    "size": 160
+    "shasum": "eb5f4e337f4a9a7616308c5314fc75c3f62a59ce921c012d1a1281038bdbbfd1",
+    "size": 99
   },
   "lambdas/feed-rerun/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -92,8 +92,8 @@
     "size": 1916
   },
   "lambdas/process/requirements.txt": {
-    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
-    "size": 160
+    "shasum": "eb5f4e337f4a9a7616308c5314fc75c3f62a59ce921c012d1a1281038bdbbfd1",
+    "size": 99
   },
   "lambdas/process/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",

--- a/tests/cli/fixtures/build/hashes.json
+++ b/tests/cli/fixtures/build/hashes.json
@@ -4,8 +4,8 @@
     "size": 40310
   },
   "lambdas/pre-batch/requirements.txt": {
-    "shasum": "e5f05c7df535c6dfb7c9eab53bbb4bdebea7ee03f1894c58410795dfcb398538",
-    "size": 166
+    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
+    "size": 160
   },
   "lambdas/pre-batch/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -16,8 +16,8 @@
     "size": 858
   },
   "lambdas/post-batch/requirements.txt": {
-    "shasum": "e5f05c7df535c6dfb7c9eab53bbb4bdebea7ee03f1894c58410795dfcb398538",
-    "size": 166
+    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
+    "size": 160
   },
   "lambdas/post-batch/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -28,8 +28,8 @@
     "size": 3161
   },
   "lambdas/update-state/requirements.txt": {
-    "shasum": "e5f05c7df535c6dfb7c9eab53bbb4bdebea7ee03f1894c58410795dfcb398538",
-    "size": 166
+    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
+    "size": 160
   },
   "lambdas/update-state/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -44,8 +44,8 @@
     "size": 7806
   },
   "lambdas/publish/requirements.txt": {
-    "shasum": "e5f05c7df535c6dfb7c9eab53bbb4bdebea7ee03f1894c58410795dfcb398538",
-    "size": 166
+    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
+    "size": 160
   },
   "lambdas/publish/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -64,8 +64,8 @@
     "size": 1403
   },
   "lambdas/api/requirements.txt": {
-    "shasum": "e5f05c7df535c6dfb7c9eab53bbb4bdebea7ee03f1894c58410795dfcb398538",
-    "size": 166
+    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
+    "size": 160
   },
   "lambdas/api/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -76,8 +76,8 @@
     "size": 8162
   },
   "lambdas/feed-rerun/requirements.txt": {
-    "shasum": "e5f05c7df535c6dfb7c9eab53bbb4bdebea7ee03f1894c58410795dfcb398538",
-    "size": 166
+    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
+    "size": 160
   },
   "lambdas/feed-rerun/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -92,8 +92,8 @@
     "size": 1916
   },
   "lambdas/process/requirements.txt": {
-    "shasum": "e5f05c7df535c6dfb7c9eab53bbb4bdebea7ee03f1894c58410795dfcb398538",
-    "size": 166
+    "shasum": "2a77a534dc996764dfd7b51ddc7d2e7dae98a3351f94eb26872a568e97664194",
+    "size": 160
   },
   "lambdas/process/__init__.py": {
     "shasum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",

--- a/tests/cli/fixtures/build/serverless.yml
+++ b/tests/cli/fixtures/build/serverless.yml
@@ -54,12 +54,7 @@ custom:
     slim: true
     slimPatternsAppendDefaults: false
     slimPatterns:
-      - botocore/**
-      - botocore-*/**
-      - boto3/**
-      - boto3-*/**
       - bin/**
-      - dateutils*
       - docutils/**
       - docutils-*/**
       - numpy/**

--- a/tests/lib/test_misc.py
+++ b/tests/lib/test_misc.py
@@ -6,11 +6,11 @@ def test_get_cirrus_geo_requirements():
         "pyyaml~=6.0",
         "click~=8.0",
         "click-plugins~=1.1",
-        "rich~=10.6",
+        "rich",
         "cfn-flip~=1.2",
         "boto3-utils~=0.4.1",
         "boto3>=1.26.0",
         "python-json-logger~=2.0",
         "jsonpath-ng>=1.5.3",
-        "python-dateutil~=2.8.2",
+        "python-dateutil~=2.9.0",
     ]

--- a/tests/lib/test_misc.py
+++ b/tests/lib/test_misc.py
@@ -1,13 +1,8 @@
 from cirrus.core.utils import misc
 
 
-def test_get_cirrus_geo_requirements():
-    assert misc.get_cirrus_geo_requirements() == [
-        "pyyaml~=6.0",
-        "click~=8.0",
-        "click-plugins~=1.1",
-        "rich",
-        "cfn-flip~=1.2",
+def test_get_cirrus_geo_lib2_requirements():
+    assert misc.get_cirrus_geo_lib2_requirements() == [
         "boto3-utils~=0.4.1",
         "boto3>=1.26.0",
         "python-json-logger~=2.0",


### PR DESCRIPTION
### Fixed

- Fixed issue [#255] for the `release/v0` branch by using a heuristic to select only the libs that cirrus.lib2 needs for injection into the python lambda requirements files. 

### Changed

- Loosened requirement `rich~=10.6` to `rich`, and bumped python-dateutil from `~2.8.2` to `~2.9.0`. Note, the sum total of `rich` usage is printing escaped character sequences to the console.  This was conflicting with other requirements in deployed lambdas.

### Removed

- Removed slimPatterns for `boto*` and `dateutil` packages, per [#242].