### PR TITLE
release prep for v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.15.2]
 
 ### Fixed
 
@@ -831,7 +831,8 @@ cleanup steps.
 
 Initial release
 
-[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.1...release/v0
+[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.2...release/v0
+[v0.15.2]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.1...v0.15.2
 [v0.15.1]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.0...v0.15.1
 [v0.15.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.14.0...v0.15.0
 [v0.14.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.13.0...v0.14.0


### PR DESCRIPTION
Release prep changes since v0.15.1 include:

### Fixed

- Fixed issue [#225] where default string is treated as a list when input
  collection is specified neither via `payload.collections` nor on the items in
  `payload.features[].collection`. ([#279])
- Fixed issue [#255] for the `release/v0` branch by using a heuristic to select
  only the libs that cirrus.lib2 needs for injection into the python lambda
  requirements files. ([#283])

### Changed

- Loosened requirement `rich~=10.6` to `rich`, and bumped python-dateutil from
  `~2.8.2` to `~2.9.0`. Note, the sum total of `rich` usage is printing
  escaped character sequences to the console. ([#283])