### PR TITLE
Re-release prep v0.15.2

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,13 +1,24 @@
-name: Upload Python Package
+name: Build Python Package
 
 on:
+  push:
+    branches:
+      - release/v0
+  pull_request:
+    branches:
+      - release/v0
   release:
-    types: [published]
+    types:
+      - published
 
 jobs:
-  deploy:
+  build-package:
     runs-on: ubuntu-latest
-
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cirrus-geo
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -17,12 +28,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-      - name: Build and publish
-        env:
-          CIRRUS_VERSION: ${{ github.event.release.tag_name }}
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_APIKEY }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/*
+          pip install build
+          pip install .
+      - name: Build package
+        run: python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
re-Release prep for gh-action change.   

### Changed

- backported github-action to use trusted provider from `main` branch.

---

Previous PR noted changes since v0.15.1 include:

### Fixed

- Fixed issue [#225] where default string is treated as a list when input
  collection is specified neither via `payload.collections` nor on the items in
  `payload.features[].collection`. ([#279])
- Fixed issue [#255] for the `release/v0` branch by using a heuristic to select
  only the libs that cirrus.lib2 needs for injection into the python lambda
  requirements files. ([#283])

### Changed

- Loosened requirement `rich~=10.6` to `rich`, and bumped python-dateutil from
  `~2.8.2` to `~2.9.0`. Note, the sum total of `rich` usage is printing
  escaped character sequences to the console. ([#283])