### PR TITLE
Release prep v0.15.3

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,9 @@ on:
     types:
       - published
 
+env:
+  CIRRUS_VERSION: ${{ github.event.release.tag_name }}
+
 jobs:
   build-package:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,12 +1,6 @@
 name: Build Python Package
 
 on:
-  push:
-    branches:
-      - release/v0
-  pull_request:
-    branches:
-      - release/v0
   release:
     types:
       - published

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,9 +1,9 @@
 name: Python Test
 on:
   push:
-    branches: main
+    branches: release/v0
   pull_request:
-    branches: main
+    branches: release/v0
 
 jobs:
   build:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,6 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v0.15.2]
+## [v0.15.3]
 
 ### Fixed
 
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 - Removed slimPatterns for `boto*` and `dateutil` packages, per [#242]. ([#283])
+
+## v0.15.2 - 2024-11-08
+
+Deleted due to github release workflow misconfiguration.
 
 ## [v0.15.1] - 2024-05-09
 
@@ -831,8 +835,8 @@ cleanup steps.
 
 Initial release
 
-[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.2...release/v0
-[v0.15.2]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.1...v0.15.2
+[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.3...release/v0
+[v0.15.3]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.1...v0.15.3
 [v0.15.1]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.0...v0.15.1
 [v0.15.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.14.0...v0.15.0
 [v0.14.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.13.0...v0.14.0

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ dependency_links = [x.strip().replace("git+", "") for x in reqs if "git+" not in
 
 setup(
     name="cirrus-geo",
-    python_requires=">=3.9",
+    python_requires=">=3.9,<3.12",
     packages=find_namespace_packages("src"),
     package_dir={"": "src"},
     version=VERSION,
@@ -83,7 +83,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
+        # "Programming Language :: Python :: 3.12", # Not ready yet
     ],
     license="Apache-2.0",
     include_package_data=True,


### PR DESCRIPTION
Administrative replacement of v0.15.2, due to GHaction misconfigurations:

1. tests were offline for `release/v0`
2. releases were attempted for non-release events
3. CIRRUS_VERSION was not set on release workflow

---

### Fixed

- Fixed issue [#225] where default string is treated as a list when input
  collection is specified neither via `payload.collections` nor on the items in
  `payload.features[].collection`. ([#279])
- Fixed issue [#255] for the `release/v0` branch by using a heuristic to select
  only the libs that cirrus.lib2 needs for injection into the python lambda
  requirements files. ([#283])

### Changed

- Loosened requirement `rich~=10.6` to `rich`, and bumped python-dateutil from
  `~2.8.2` to `~2.9.0`. Note, the sum total of `rich` usage is printing
  escaped character sequences to the console. ([#283])

### Removed

- Removed slimPatterns for `boto*` and `dateutil` packages, per [#242]. ([#283])
