### PR TITLE
release/v0 python 3.12 compatibility

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,6 +13,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -38,10 +38,11 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --statistics
       - name: Test with pytest
         run: pytest --cov=cirrus --cov-report=xml
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          fail_ci_if_error: true
-          verbose: true
+      ## commented due to upload issues and urgency
+      # - name: "Upload coverage to Codecov"
+      #   uses: codecov/codecov-action@v4
+      #   env:
+      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      #   with:
+      #     fail_ci_if_error: true
+      #     verbose: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ boto3>=1.26.0
 python-json-logger~=2.0
 jsonpath-ng>=1.5.3
 python-dateutil~=2.9.0
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def git_version(gitdir, default="0.0.0"):
     #  3 - dirty (if repo state is dirty)
     parts = desc.stdout.decode().strip().lstrip("v").split("-", maxsplit=2)
     if int(parts[1]) > 0 or "dirty" in parts[2]:
-        return f'{parts[0]}+{parts[1]}.{parts[2].replace("-",".")}'
+        return f'{parts[0]}+{parts[1]}.{parts[2].replace("-", ".")}'
     else:
         return parts[0]
 
@@ -66,7 +66,7 @@ dependency_links = [x.strip().replace("git+", "") for x in reqs if "git+" not in
 
 setup(
     name="cirrus-geo",
-    python_requires=">=3.9,<3.12",
+    python_requires=">=3.9",
     packages=find_namespace_packages("src"),
     package_dir={"": "src"},
     version=VERSION,

--- a/src/cirrus/core/cloudformation/templates/__init__.py
+++ b/src/cirrus/core/cloudformation/templates/__init__.py
@@ -1,4 +1,8 @@
-import importlib.resources as _ir
+try:
+    import importlib.resources._legacy as _ir
+except ImportError:
+    import importlib.resources as _ir
+
 
 TEMPLATE_EXT = ".yml"
 

--- a/src/cirrus/core/utils/misc.py
+++ b/src/cirrus/core/utils/misc.py
@@ -17,7 +17,14 @@ def get_cirrus_geo_lib2_requirements() -> list[str]:
         for lib_req in full_reqs
         if not any(
             lib_req.startswith(main_req)
-            for main_req in ("pyyaml", "click", "click-plugins", "rich", "cfn-flip")
+            for main_req in (
+                "pyyaml",
+                "click",
+                "click-plugins",
+                "rich",
+                "cfn-flip",
+                "setuptools",
+            )
         )
     ]
 


### PR DESCRIPTION
Since the tests were offlined for this branch at fork time, we did not catch the python 3.12 requirements issue with `importlib.resources` usage.  

Also, due usage in `core/components/base/_lambda.py`, `setuptools` is actually a requirement of the cirrus application, not just the build/install system.