### PR TITLE
Release prep v0.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.15.4]
 
 ### Fixed
 
@@ -844,7 +844,8 @@ cleanup steps.
 
 Initial release
 
-[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.3...release/v0
+[unreleased]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.4...release/v0
+[v0.15.4]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.3...v0.15.4
 [v0.15.3]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.1...v0.15.3
 [v0.15.1]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.15.0...v0.15.1
 [v0.15.0]: https://github.com/cirrus-geo/cirrus-geo/compare/v0.14.0...v0.15.0


### PR DESCRIPTION
## Bugfix release

### Fixed

- Pass payload, not string version of payload, when string version is larger
  than `MAX_PAYLOAD_LENGTH` is exceeded. ([#292])