### PR TITLE
Add execution ARN to succeeded event

### DIFF
--- a/src/cirrus/lib/events.py
+++ b/src/cirrus/lib/events.py
@@ -313,6 +313,7 @@ class WorkflowEventManager:
                 payload_id=payload_id,
                 isotimestamp=isotimestamp,
                 payload_url=payload_url,
+                execution_arn=execution_arn,
             ),
         )
 


### PR DESCRIPTION
Adds the step function execution ARN to workflow events of type `SUCCEEDED` sent to the workflow event topic. See #296.