### PR TITLE
Updating Cirrus docs for CLI parameter store changes

### DIFF
--- a/docs/src/cirrus/cli/00_intro.rst
+++ b/docs/src/cirrus/cli/00_intro.rst
@@ -6,19 +6,17 @@ Introduction
 Cirrus itself is `STAC`_-based geospatial processing pipeline platform deployed
 on AWS and is a constellation of associated pieces of AWS infrastructure.  The
 pieces of a Cirrus deployment like the lambdas, SQS, S3 buckets and other can be
-managed and interacted with using common AWS management tools, either from the
-AWS GUI or AWS CLI.  However the nature of a Cirrus deployment can make direct
+managed and interacted with using common AWS management tools like the AWS GUI
+or AWS CLI.  However the nature of a Cirrus deployment can make direct
 management via AWS tools difficult to do things like batch reruns, manage
-deployments, individual invokations, and more.  There can be multiple cirrus
-deployments, and Cirrus infrastructure like SQS queues, S3 buckets, and lambdas
-may co-exist in an AWS account with non Cirrus resources further complicating
-this management.
+deployments, individual lambda invocations, and more.  There can be multiple
+cirrus deployments and Cirrus infrastructure may co-exist in an AWS account with non Cirrus resources further complicating this management.
 
 What Is CLIrrus?
 ----------------
-To ease the management of a cirrus deployment, the cirrus-geo library has a
+To ease the management of a cirrus deployment the cirrus-geo library has a
 built in command line tool (CLIrrus) designed to streamline the developer
-experience when using and managing a Cirrus deployment.
+experience when using and interacting with a Cirrus deployment.
 
 CLIrrus is a python CLI tool built using the `click`_ library with commmands
 specific to Cirrus.  Example use cases would be to list all available cirrus

--- a/docs/src/cirrus/cli/00_intro.rst
+++ b/docs/src/cirrus/cli/00_intro.rst
@@ -42,7 +42,7 @@ CLIrrus Quick Start
 -------------------
 If you understand the broader background and structure of Cirrus, cirrus
 deployments and the cirrus CLI tool and you want to jump right into using the
-CLI tool here is what an example workflow might look like:
+CLI tool here is what an example workflow might look like.  These are one way of accomplishing these steps, personal and organizatonal requirements may differ.
 
 1. Install requirements
 
@@ -50,7 +50,7 @@ CLI tool here is what an example workflow might look like:
 
     python3.12 -m venv .venv
     source .venv/bin/activate
-    pip install cirrus-geo>=1.0.0
+    pip install 'cirrus-geo[cli]>=1.0.0'
 
 2. Authenticate (if necessary)
 

--- a/docs/src/cirrus/cli/00_intro.rst
+++ b/docs/src/cirrus/cli/00_intro.rst
@@ -50,9 +50,9 @@ CLI tool here is what an example workflow might look like:
 
     python3.12 -m venv .venv
     source .venv/bin/activate
-    pip install -r requirements-dev.txt -r requirements-cli.txt -r requirements.txt
+    pip install cirrus-geo>=1.0.0
 
-2. Authenticate
+2. Authenticate (if necessary)
 
 .. code-block:: bash
 
@@ -63,14 +63,6 @@ CLI tool here is what an example workflow might look like:
 .. code-block:: bash
 
     cirrus mgmt deployment-name-here list-lambdas
-
-If your cirrus resources are in a different region from the account sso region
-you can use a region flag
-
-.. code-block:: bash
-
-    cirrus --region us-west-2 mgmt deployment-name-here list-lambdas
-
 
 And thats it!  If you would like more in depth explanations on how to use the
 tool, please proceed.

--- a/docs/src/cirrus/cli/00_intro.rst
+++ b/docs/src/cirrus/cli/00_intro.rst
@@ -1,0 +1,82 @@
+CLIrrus - The Cirrus CLI management Tool
+========================================
+
+Introduction
+------------
+Cirrus itself is `STAC`_-based geospatial processing pipeline platform deployed
+on AWS and is a constellation of associated pieces of AWS infrastructure.  The
+pieces of a Cirrus deployment like the lambdas, SQS, S3 buckets and other can be
+managed and interacted with using common AWS management tools, either from the
+AWS GUI or AWS CLI.  However the nature of a Cirrus deployment can make direct
+management via AWS tools difficult to do things like batch reruns, manage
+deployments, individual invokations, and more.  There can be multiple cirrus
+deployments, and Cirrus infrastructure like SQS queues, S3 buckets, and lambdas
+may co-exist in an AWS account with non Cirrus resources further complicating
+this management.
+
+What Is CLIrrus?
+----------------
+To ease the management of a cirrus deployment, the cirrus-geo library has a
+built in command line tool (CLIrrus) designed to streamline the developer
+experience when using and managing a Cirrus deployment.
+
+CLIrrus is a python CLI tool built using the `click`_ library with commmands
+specific to Cirrus.  Example use cases would be to list all available cirrus
+deployments, list lambdas in a given deployment, and even directly trigger a
+workflow with an input Payload by sending the payload directly to the SQS queue
+monitored by the Process lambda, and more.
+
+What if I'm using an older version of Cirrus?
+---------------------------------------------
+
+You can use the `older CLI tool`_ which is a standalone module and can be
+installed via pip.
+
+How To Use CLIrrus?
+-------------------
+A few simple steps are all it takes to set up CLIrrus for use.
+
+1. Install
+2. Authenticatie
+3. Run commands
+
+CLIrrus Quick Start
+-------------------
+If you understand the broader background and structure of Cirrus, cirrus
+deployments and the cirrus CLI tool and you want to jump right into using the
+CLI tool here is what an example workflow might look like:
+
+1. Install requirements
+
+.. code-block:: bash
+
+    python3.12 -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements-dev.txt -r requirements-cli.txt -r requirements.txt
+
+2. Authenticate
+
+.. code-block:: bash
+
+    aws sso login --profile your-config-profile-here
+
+3. Use CLIrrus
+
+.. code-block:: bash
+
+    cirrus mgmt deployment-name-here list-lambdas
+
+If your cirrus resources are in a different region from the account sso region
+you can use a region flag
+
+.. code-block:: bash
+
+    cirrus --region us-west-2 mgmt deployment-name-here list-lambdas
+
+
+And thats it!  If you would like more in depth explanations on how to use the
+tool, please proceed.
+
+.. _click: https://click.palletsprojects.com/en/stable/
+.. _STAC: https://stacspec.org/
+.. _older CLI tool: https://pypi.org/project/cirrus-mgmt/

--- a/docs/src/cirrus/cli/01_install.rst
+++ b/docs/src/cirrus/cli/01_install.rst
@@ -1,0 +1,16 @@
+Installing the Cirrus CLI Management Tool (CLIrrus)
+===================================================
+Installing CLIrrus is quick and easy.  Built using python `click`_ library and included in the broader `cirrus-geo`_ library, to install CLIrrus you just need to install the cirrus-geo project requirements.
+
+For superior environment management we recommend you create a specific virtual environment.  This can be accomplised using your preferred environment management tools.  One way might be as follows:
+
+.. code-block:: bash
+
+    python3.12 -m venv .venv
+
+    source .venv/bin/activate
+
+    pip install -r requirements-dev.txt -r requirements-cli.txt -r requirements.txt
+
+.. _click: https://click.palletsprojects.com/en/stable/
+.. _cirrus-geo: https://github.com/cirrus-geo/cirrus-geo

--- a/docs/src/cirrus/cli/01_install.rst
+++ b/docs/src/cirrus/cli/01_install.rst
@@ -1,6 +1,6 @@
 Installing the Cirrus CLI Management Tool (CLIrrus)
 ===================================================
-Installing CLIrrus is quick and easy.  Built using python `click`_ library and included in the broader `cirrus-geo`_ library, to install CLIrrus you just need to install the cirrus-geo project requirements.
+Installing CLIrrus is quick and easy.  Built using python `click`_ library and included in the broader `cirrus-geo`_ library, to install CLIrrus you just need to install the ``cirrus-geo`` project requirements.
 
 For superior environment management we recommend you create a specific virtual environment.  This can be accomplised using your preferred environment management tools.  One way might be as follows:
 

--- a/docs/src/cirrus/cli/01_install.rst
+++ b/docs/src/cirrus/cli/01_install.rst
@@ -10,7 +10,7 @@ For superior environment management we recommend you create a specific virtual e
 
     source .venv/bin/activate
 
-    pip install -r requirements-dev.txt -r requirements-cli.txt -r requirements.txt
+    pip install .
 
 .. _click: https://click.palletsprojects.com/en/stable/
 .. _cirrus-geo: https://github.com/cirrus-geo/cirrus-geo

--- a/docs/src/cirrus/cli/02_auth.rst
+++ b/docs/src/cirrus/cli/02_auth.rst
@@ -1,0 +1,36 @@
+CLIrrus Authentication
+=========================
+
+Because CLIrrus interacts directly with AWS resources via the
+AWS python API with the boto3 library, you will have to be authenticated with AWS. The easiest way to do this will be to use the `AWS CLI tool`_ and install as necessary for your system/needs
+
+CLIrrus will only need to be installed once, but authenticatig with AWS
+will be necessary for each new session as AWS credentials expire and must be
+renewed.  The best way to retrieve and store these credentials is with the AWS CLI single sign on (SSO) option.
+
+To execute the AWS SSO command you will need to have an `AWS config file`_ so
+that the AWS CLI SSO command can access the necessary account information in
+that config file.
+
+A config file needs to live in the discoverable ``.aws/config`` location. The
+config file is broken into sections for different profiles that are assigned
+names of your choice.
+
+Required key value pairs are:
+
+- sso_session: A user assigned name given to the session
+- sso_account_id: AWS account ID to use to authenticate
+- sso_role_name: A valid AWS role assigned to the account ID
+- region: AWS Region to SSO into
+
+After you can built your config file you can login with
+
+
+.. code-block:: bash
+
+    aws sso login --profile your-named-profile
+
+One you have successfully SSO'd setup will be complete for CLIrrus
+
+.. _AWS CLI tool: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+.. _AWS config file: https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html

--- a/docs/src/cirrus/cli/02_auth.rst
+++ b/docs/src/cirrus/cli/02_auth.rst
@@ -2,28 +2,15 @@ CLIrrus Authentication
 =========================
 
 Because CLIrrus interacts directly with AWS resources via the
-AWS python API with the boto3 library, you will have to be authenticated with AWS. The easiest way to do this will be to use the `AWS CLI tool`_.
+AWS python API with the boto3 library, you will have to be authenticated with AWS.  We recommend folllowing your organizations best practice recommendations for authentication. One way you could do so is to use the `AWS CLI tool`_.
+
+Look `here`_ for an in depth explanation of authentication options with the AWS command line tool and how to configure SSO login.
 
 CLIrrus will only need to be installed once, but authenticatig with AWS
 will be necessary for each new session as AWS credentials expire and must be
-refreshed every so often.  The best way to retrieve and store these credentials is with the AWS CLI single sign on (SSO) option.
+refreshed every so often.  This can be easily accomplished with the AWS CLI single sign on (SSO) option.
 
-To execute the AWS SSO command you will need to have an `AWS config file`_ so
-that the AWS CLI SSO command can access the necessary account information in
-that config file.
-
-A config file needs to live in the discoverable ``.aws/config`` location. The
-config file is broken into sections for different profiles that are assigned
-names of your choice.
-
-Required key value pairs are:
-
-- sso_session: A user assigned name given to the session
-- sso_account_id: AWS account ID to use to authenticate
-- sso_role_name: A valid AWS role assigned to the account ID
-- region: AWS Region to SSO into
-
-After you have built your config file you can login with
+After you have built your config file according to organizatonal or personal preference you can login with
 
 .. code-block:: bash
 
@@ -33,3 +20,4 @@ One you have successfully SSO'd setup will be complete for CLIrrus
 
 .. _AWS CLI tool: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 .. _AWS config file: https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html
+.. _here: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html

--- a/docs/src/cirrus/cli/02_auth.rst
+++ b/docs/src/cirrus/cli/02_auth.rst
@@ -2,11 +2,11 @@ CLIrrus Authentication
 =========================
 
 Because CLIrrus interacts directly with AWS resources via the
-AWS python API with the boto3 library, you will have to be authenticated with AWS. The easiest way to do this will be to use the `AWS CLI tool`_ and install as necessary for your system/needs
+AWS python API with the boto3 library, you will have to be authenticated with AWS. The easiest way to do this will be to use the `AWS CLI tool`_.
 
 CLIrrus will only need to be installed once, but authenticatig with AWS
 will be necessary for each new session as AWS credentials expire and must be
-renewed.  The best way to retrieve and store these credentials is with the AWS CLI single sign on (SSO) option.
+refreshed every so often.  The best way to retrieve and store these credentials is with the AWS CLI single sign on (SSO) option.
 
 To execute the AWS SSO command you will need to have an `AWS config file`_ so
 that the AWS CLI SSO command can access the necessary account information in
@@ -23,8 +23,7 @@ Required key value pairs are:
 - sso_role_name: A valid AWS role assigned to the account ID
 - region: AWS Region to SSO into
 
-After you can built your config file you can login with
-
+After you have built your config file you can login with
 
 .. code-block:: bash
 

--- a/docs/src/cirrus/cli/03_deployments.rst
+++ b/docs/src/cirrus/cli/03_deployments.rst
@@ -4,26 +4,30 @@ CLIrrus and Cirrus deployments
 CLIrrus is designed around interacting with a different cirrus deployments. Many
 of the commands are focused on interacting with a specific cirrus 'deployment',
 like invoking a specific workflow to run in a specific deployment.  A 'cirrus
-deployment' can be considered to be the collection of related AWS resources.   For CLIrrus, a 'deployment' is represented as a collection of essential environment
-variables that are necessary to interact with the correct AWS resources for a
-deployment, like relevant ARNs or SQS queue URLs.  The information for
-connecting to the correct rsources is stored in the `AWS Parameter Store`_
+deployment' can be considered to be the collection of related AWS resources for
+a single cirrus deployment.   For CLIrrus, a 'deployment' is represented as a
+collection of essential environment variables that are necessary to interact
+with the correct AWS resources for a deployment, like relevant ARNs or SQS queue
+URLs.  These environment variables for connecting to the correct resources are stored in the `AWS Parameter Store`_
 
 Deployments and Parameter Store
 -------------------------------
 
-As previously mentined, using CLIrrus requires knowing deployment specific environment variables to make AWS API calls to the correct resources.  These environment
-variables are stored in the AWS Parameter Store.  For example, the Process
-lambda requires the "CIRRUS_PAYLOAD_BUCKET" environment variable to know what
-bucket to dump payloads into for storage.  When running commands on a specific deployment CLIrrus will automatically retrieve these environment variables based on the deployment name you pass.
+As previously mentined, using CLIrrus requires knowing deployment specific
+environment variables to make AWS API calls to the correct resources.  These
+environment variables are stored in the AWS Parameter Store.  For example, the
+Process lambda requires the "CIRRUS_PAYLOAD_BUCKET" environment variable to know
+what bucket to dump payloads into for storage.  When running commands on a
+specific deployment CLIrrus will automatically retrieve these environment
+variables based on the deployment name you pass.
 
 Parameter Store
 ---------------
 
 The parameter store has a hierarchical storage system centered around the use of
-"/" in parameter names. More information on parameter hierachies can be found on the `AWS parameter store documentation`_.  This hierarchial organization is used to ensure deployments can be found under common prefixes, and enables for easy use if you wish to directly search the parameter store yourself.
+``/`` in parameter names. More information on parameter hierachies can be found on the `AWS parameter store documentation`_.  This hierarchial organization is used to ensure deployments can be found under common prefixes, and enables for easy use if you wish to directly search the parameter store yourself.
 
-CLIrrus utilizes the parameter store to store these critical environment variables for different deployments.  When you run a command on a specific named cirrus deployment CLIrrus first retrieves the environmental variables for that cirrus deployment from the parameter store.
+CLIrrus utilizes the parameter store to store these critical environment variables for different deployments.  When you run a command on a specific named cirrus deployment CLIrrus first retrieves the environmental variables for that cirrus deployment from the parameter store and then uses them to execute commands like ``list-lambdas``
 
 A pointer system is used to identify the parameter store prefix for a given deployment to ensure that we can search and retrieve only the enviroment variables for a given deployment without having to parse a large amount of returned parameters.  Using this pointer CLIrrus can then retrieve the related environment variables.
 

--- a/docs/src/cirrus/cli/03_deployments.rst
+++ b/docs/src/cirrus/cli/03_deployments.rst
@@ -1,0 +1,33 @@
+CLIrrus and Cirrus deployments
+==============================
+
+CLIrrus is designed around interacting with a different cirrus deployments. Many
+of the commands are focused on interacting with a specific cirrus 'deployment',
+like invoking a specific workflow to run in a specific deployment.  A 'cirrus
+deployment' can be considered to be the collection of related AWS resources.   For CLIrrus, a 'deployment' is represented as a collection of essential environment
+variables that are necessary to interact with the correct AWS resources for a
+deployment, like relevant ARNs or SQS queue URLs.  The information for
+connecting to the correct rsources is stored in the `AWS Parameter Store`_
+
+Deployments and Parameter Store
+-------------------------------
+
+As previously mentined, using CLIrrus requires knowing deployment specific environment variables to make AWS API calls to the correct resources.  These environment
+variables are stored in the AWS Parameter Store.  For example, the Process
+lambda requires the "CIRRUS_PAYLOAD_BUCKET" environment variable to know what
+bucket to dump payloads into for storage.  When running commands on a specific deployment CLIrrus will automatically retrieve these environment variables based on the deployment name you pass.
+
+Parameter Store
+---------------
+
+The parameter store has a hierarchical storage system centered around the use of
+"/" in parameter names. More information on parameter hierachies can be found on the `AWS parameter store documentation`_.  This hierarchial organization is used to ensure deployments can be found under common prefixes, and enables for easy use if you wish to directly search the parameter store yourself.
+
+CLIrrus utilizes the parameter store to store these critical environment variables for different deployments.  When you run a command on a specific named cirrus deployment CLIrrus first retrieves the environmental variables for that cirrus deployment from the parameter store.
+
+A pointer system is used to identify the parameter store prefix for a given deployment to ensure that we can search and retrieve only the enviroment variables for a given deployment without having to parse a large amount of returned parameters.  Using this pointer CLIrrus can then retrieve the related environment variables.
+
+These environment variables are automatically created in the parameter store by the terraform code that also deploys cirrus resources.
+
+.. _AWS Parameter Store: https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html
+.. _AWS Parameter store documentation: https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-hierarchies.html

--- a/docs/src/cirrus/cli/04_commands.rst
+++ b/docs/src/cirrus/cli/04_commands.rst
@@ -57,7 +57,7 @@ Manage commands
 
     .. code-block:: bash
 
-        cirrus mgmt kodiak get-execution-input --arn arn:aws:states:us-west-2:000000000011:execution:fd-name-dev-cirrus-project:c123456789-b19292-999
+        cirrus mgmt name-dev get-execution-input --arn arn:aws:states:us-west-2:000000000011:execution:fd-name-dev-cirrus-project:c123456789-b19292-999
 
         cirrus mgmt name-dev get-execution-input --payload-id sar/workflow-test/example-01_2024-10-31-06-05-10
 
@@ -89,12 +89,7 @@ Manage commands
 
     .. code-block:: bash
 
-        cirrus mgmt name-dev invoke-lambda process
-        {
-            "type": "FeatureCollection",
-            "process": [{"workflow": "example"}],
-            "features": []
-        }
+        cat payload.json | cirrus mgmt name-dev invoke-lambda process
 
 - *list-lambdas*:
     List all lambda functions available in a given deployment
@@ -108,24 +103,14 @@ Manage commands
 
     .. code-block:: bash
 
-        cirrus mgmt name-dev process
-        {
-            "type": "FeatureCollection",
-            "process": [{"workflow": "example"}],
-            "features": []
-        }
+        cat payload.json | cirrus mgmt name-dev process
 
 - *run-workflow:*
     Pass a payload (from stdin) off to a deployment wait for the workflow to finish, retrieve and return its output payload
 
     .. code-block:: bash
 
-        cirrus mgmt name-dev run-workflow
-        {
-            "type": "FeatureCollection",
-            "process": [{"workflow": "example"}],
-            "features": []
-        }
+        cat payload.json | cirrus mgmt name-dev run-workflow
 
 - *show:*
     Show a deployment configuration's environment variables available in the parameter store
@@ -150,32 +135,18 @@ Payload commands
 
     .. code-block:: bash
 
-        cirrus payload get-id
-        {
-            "type": "FeatureCollection",
-            "process": [{"workflow": "example"}],
-            "features": []
-        }
+        cat payload.json | cirrus payload get-id
 
 - *template:*
     Template a payload (from stdin) with user supplied variables with '$' based substitution
 
     .. code-block:: bash
 
-        cirrus payload template --var EXAMPLE_VAR VALUE
-        {
-            "type": "FeatureCollection",
-            "process": [{"workflow": $EXAMPLE_VAR}],
-            "features": []
-        }
+        cat payload.json | cirrus payload template --var EXAMPLE_VAR VALUE
+
 - *validate:*
     Validate an input payload (from stdin) is a valid cirrus payload
 
     .. code-block:: bash
 
-        cirrus payload validate
-        {
-            "type": "FeatureCollection",
-            "process": [{"workflow": "example"}],
-            "features": []
-        }
+        cat payload.json | cirrus payload validate

--- a/docs/src/cirrus/cli/04_commands.rst
+++ b/docs/src/cirrus/cli/04_commands.rst
@@ -1,0 +1,181 @@
+CLIrrus commands
+================
+
+CLIrrus currently support a number of commands.
+
+- *list-deployments:*
+    Return a list of all named cirrus deployments available for interacting
+    with by pulling deployments available in AWS parameter store.  Defaults to looking in the region used in AWS SSO login.  Names returned here will be the name strings needed to run commands on a specific deployment.
+
+    .. code-block:: bash
+
+        cirrus list-deployments
+
+- *manage (mgmt):*
+    A wrapper for commands to interact with a specific named deployment
+
+    .. code-block:: bash
+
+        cirrus mgmt DEPLOYMENT_NAME COMMAND
+
+
+- *payload:*
+    a wrapper for commands for working with payloads.
+
+    .. code-block:: bash
+
+        cirrus payload COMMAND
+
+
+Manage commands
+---------------
+- *call:*
+    Call a new command with the deployment environment variables loaded
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev call ls
+
+- *exec:*
+    Run an executable with the deployment specific environment variables loaded into the local environment
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev exec "bash" "hello_env_var_world.sh"
+
+- *get-execution:*
+    Get a workflow execution using its ARN or its payload-id
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev get-execution --payload-id sar/workflow-test/example-01_2024-10-31-06-05-10
+
+        cirrus mgmt name-dev get-execution --arn arn:aws:states:us-west-2:000000000011:execution:fd-name-dev-cirrus-project:c123456789-b19292-999
+
+- *get-execution-input:*
+    Get a workflow execution's input payload using ARN or payload-id
+
+    .. code-block:: bash
+
+        cirrus mgmt kodiak get-execution-input --arn arn:aws:states:us-west-2:000000000011:execution:fd-name-dev-cirrus-project:c123456789-b19292-999
+
+        cirrus mgmt name-dev get-execution-input --payload-id sar/workflow-test/example-01_2024-10-31-06-05-10
+
+- *get-execution-output:*
+    Get a workflow execution's output payload using payload-id or ARN
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev get-execution-output --payload-id sar/workflow-test/example-01_2024-10-31-06-05-10
+
+        cirrus mgmt name-dev get-execution-output --arn arn:aws:states:us-west-2:000000000011:execution:fd-name-dev-cirrus-project:c123456789-b19292-999
+
+- *get-payload:*
+    Get a payload from S3 using its ID
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev get-payload sar/workflow-test/example-01_2024-10-31-06-05-10
+
+- *get-state:*
+    Get the stateDB record for a payload ID
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev get-state sar/workflow-test/example-01_2024-10-31-06-05-10
+
+- *invoke-lambda:*
+    Invoke lambda with event (from stdin) and specifying by name which lambda to invoke
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev invoke-lambda process
+        {
+            "type": "FeatureCollection",
+            "process": [{"workflow": "example"}],
+            "features": []
+        }
+
+- *list-lambdas*:
+    List all lambda functions available in a given deployment
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev list-lambdas
+
+- *process:*
+    Enqueue a payload (from stdin) for processing
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev process
+        {
+            "type": "FeatureCollection",
+            "process": [{"workflow": "example"}],
+            "features": []
+        }
+
+- *run-workflow:*
+    Pass a payload (from stdin) off to a deployment wait for the workflow to finish, retrieve and return its output payload
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev run-workflow
+        {
+            "type": "FeatureCollection",
+            "process": [{"workflow": "example"}],
+            "features": []
+        }
+
+- *show:*
+    Show a deployment configuration's environment variables available in the parameter store
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev show
+
+- *template-payload:*
+    Template a payload using a deployment's environment variables and '$' based substitution
+
+    .. code-block:: bash
+
+        cirrus mgmt name-dev template-payload
+
+
+Payload commands
+----------------
+
+- *get-id:*
+    Get/generate an ID for a given payload
+
+    .. code-block:: bash
+
+        cirrus payload get-id
+        {
+            "type": "FeatureCollection",
+            "process": [{"workflow": "example"}],
+            "features": []
+        }
+
+- *template:*
+    Template a payload (from stdin) with user supplied variables with '$' based substitution
+
+    .. code-block:: bash
+
+        cirrus payload template --var EXAMPLE_VAR VALUE
+        {
+            "type": "FeatureCollection",
+            "process": [{"workflow": $EXAMPLE_VAR}],
+            "features": []
+        }
+- *validate:*
+    Validate an input payload (from stdin) is a valid cirrus payload
+
+    .. code-block:: bash
+
+        cirrus payload validate
+        {
+            "type": "FeatureCollection",
+            "process": [{"workflow": "example"}],
+            "features": []
+        }

--- a/docs/src/cirrus/cli/04_commands.rst
+++ b/docs/src/cirrus/cli/04_commands.rst
@@ -89,7 +89,7 @@ Manage commands
 
     .. code-block:: bash
 
-        cat payload.json | cirrus mgmt name-dev invoke-lambda process
+        <payload.json cirrus mgmt name-dev invoke-lambda process
 
 - *list-lambdas*:
     List all lambda functions available in a given deployment
@@ -103,14 +103,14 @@ Manage commands
 
     .. code-block:: bash
 
-        cat payload.json | cirrus mgmt name-dev process
+        <payload.json cirrus mgmt name-dev process
 
 - *run-workflow:*
     Pass a payload (from stdin) off to a deployment, wait for the workflow to finish, and retrieve and return its output payload
 
     .. code-block:: bash
 
-        cat payload.json | cirrus mgmt name-dev run-workflow
+        <payload.json cirrus mgmt name-dev run-workflow
 
 - *show:*
     Show a deployment configuration's environment variables available in the parameter store
@@ -124,7 +124,7 @@ Manage commands
 
     .. code-block:: bash
 
-        cat payload.json | cirrus mgmt name-dev template-payload --var EXAMPLE_VAR VALUE
+        <payload.json cirrus mgmt name-dev template-payload --var EXAMPLE_VAR VALUE
 
 
 Payload commands
@@ -135,18 +135,18 @@ Payload commands
 
     .. code-block:: bash
 
-        cat payload.json | cirrus payload get-id
+        <payload.json cirrus payload get-id
 
 - *template:*
     Template a payload (from stdin) with user supplied variables with '$' based substitution
 
     .. code-block:: bash
 
-        cat payload.json | cirrus payload template --var EXAMPLE_VAR VALUE
+        <payload.json cirrus payload template --var EXAMPLE_VAR VALUE
 
 - *validate:*
     Validate an input payload (from stdin) is a valid cirrus payload
 
     .. code-block:: bash
 
-        cat payload.json | cirrus payload validate
+        <payload.json cirrus payload validate

--- a/docs/src/cirrus/cli/04_commands.rst
+++ b/docs/src/cirrus/cli/04_commands.rst
@@ -71,7 +71,7 @@ Manage commands
         cirrus mgmt name-dev get-execution-output --arn arn:aws:states:us-west-2:000000000011:execution:fd-name-dev-cirrus-project:c123456789-b19292-999
 
 - *get-payload:*
-    Get a payload from S3 using its ID
+    Get a payload from S3 using its payload ID
 
     .. code-block:: bash
 
@@ -106,7 +106,7 @@ Manage commands
         cat payload.json | cirrus mgmt name-dev process
 
 - *run-workflow:*
-    Pass a payload (from stdin) off to a deployment wait for the workflow to finish, retrieve and return its output payload
+    Pass a payload (from stdin) off to a deployment, wait for the workflow to finish, and retrieve and return its output payload
 
     .. code-block:: bash
 

--- a/docs/src/cirrus/cli/04_commands.rst
+++ b/docs/src/cirrus/cli/04_commands.rst
@@ -124,7 +124,7 @@ Manage commands
 
     .. code-block:: bash
 
-        cirrus mgmt name-dev template-payload
+        cat payload.json | cirrus mgmt name-dev template-payload --var EXAMPLE_VAR VALUE
 
 
 Payload commands


### PR DESCRIPTION
Updating the cirrus documentation after reworking the cirrus cli management tool to use parameter store for holding deployment environment variables.  Currently in parallel with https://github.com/cirrus-geo/cirrus-geo/pull/295 where the CLI changes are being made.