### PR TITLE
Update how update-state lambda retrieves errors from step function

### DIFF
--- a/tests/lambda_functions/test_update_state.py
+++ b/tests/lambda_functions/test_update_state.py
@@ -161,7 +161,7 @@ def test_get_execution_error(event, error):
         extracted_error = get_execution_error(event)
         assert extracted_error == {
             "Error": "Unknown",
-            "Cause": "update-state failed to find a specific error condition.",
+            "Cause": "no error was found in event.  Check that 'state-machine.json' schema is configured to pass out errors from FAIL state",  # noqa: E501
         }
 
 

--- a/tests/lambda_functions/test_update_state.py
+++ b/tests/lambda_functions/test_update_state.py
@@ -4,6 +4,7 @@ from itertools import product
 
 import pytest
 
+from cirrus.lambda_functions.update_state import get_execution_error
 from cirrus.lambda_functions.update_state import lambda_handler as update_state
 from cirrus.lib.enums import SfnStatus
 from cirrus.lib.events import WorkflowEvent
@@ -128,11 +129,40 @@ def test_success(event, statedb, publish_topic, publish_enabled, monkeypatch):
 
 def test_failed(event, statedb):
     event["detail"]["status"] = "FAILED"
+    event["detail"]["error"] = {
+        "Error": "UnknownError",
+        "Cause": '{"errorMessage": "/usr/local/bin/python: No module named name-delivery-to-stac", "errorType": "UnknownError", "requestId": "fake-request-id-djdj10102jd", "stackTrace": ["  File \\"/var/task/post_batch.py\\", line 66, in lambda_handler\\n    raise exception_class(error_msg)\\n"]}',  # noqa: E501
+    }
     update_state(event, {})
 
     items = statedb.get_dbitems(payload_ids=[EVENT_PAYLOAD_ID])
     assert len(items) == 1
     assert items[0]["state_updated"].startswith("FAILED")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        {
+            "Error": "UnknownError",
+            "Cause": '{"errorMessage": "/usr/local/bin/python: No module named umbra-delivery-to-stac", "errorType": "UnknownError", "requestId": "20df8b93-a10f-44b2-8b50-72d82b01569d", "stackTrace": ["  File \\"/var/task/post_batch.py\\", line 66, in lambda_handler\\n    raise exception_class(error_msg)\\n"]}',  # noqa: E501
+        },
+        None,
+    ],
+)
+def test_get_execution_error(event, error):
+    event["detail"]["status"] = "FAILED"
+    event["detail"]["error"] = error
+
+    if error:
+        extracted_error = get_execution_error(event)
+        assert extracted_error == error
+    else:
+        extracted_error = get_execution_error(event)
+        assert extracted_error == {
+            "Error": "Unknown",
+            "Cause": "update-state failed to find a specific error condition.",
+        }
 
 
 def test_timed_out(event, statedb):

--- a/tests/lambda_functions/test_update_state.py
+++ b/tests/lambda_functions/test_update_state.py
@@ -161,7 +161,7 @@ def test_get_execution_error(event, error):
         extracted_error = get_execution_error(event)
         assert extracted_error == {
             "Error": "Unknown",
-            "Cause": "no error was found in event.  Check that 'state-machine.json' schema is configured to pass out errors from FAIL state",  # noqa: E501
+            "Cause": "No error was found in event.  Check Fail is configured to pass error/cause",  # noqa: E501
         }
 
 


### PR DESCRIPTION
closing #309 

If the `Fail` state is correctly passing an error out of the step function in the event of a failure and extract the error information from the payload.

Eliminating the calls to go through step function execution history will help prevent throttling issues in the event of large numbers of failed workflows.  

Documentation of change:
- #306 has some additional documentation in the `workflows` readme to explain how to configure a FAIL state to pass errors into the output payload.  
- #308 flags this as a breaking change
- Log message in PR now reminds users to ensure their `state-machine.json` files are properly designed to pass the error out, as the presence of the error in the output payload is dependent on users configuring their state machine definitions and not determined by the default cirrus terraform.