### PR TITLE
Fix: Docs version widget

### DIFF
--- a/docs/src/static/js/versions-loader.js
+++ b/docs/src/static/js/versions-loader.js
@@ -1,6 +1,11 @@
-const dataRootUrl = document
-  .getElementById("documentation_options")
-  .getAttribute("data-url_root");
+let dataRootUrl = "";
+const docOptionsElm = document.getElementById("documentation_options");
+const htmlElm = document.getElementsByTagName("html")[0];
+if (docOptionsElm) {
+  dataRootUrl = docOptionsElm.getAttribute("data-url_root");
+} else {
+  dataRootUrl = htmlElm.getAttribute("data-content_root");
+}
 
 const findRoot = () => {
   const href = window.location.href;


### PR DESCRIPTION
The github pages version widget broke.

It broke between version v0.10.1 and v0.11.0.

Looking at the diff its unclear why things broke then, there was no change to the javascript `versions-loaders.js`.  

The `actions/checkout` and `actions/setup-python` version were bumped but I doubt that was the source of the issue.  This fix aims to ensure backwards compatibility since we have to find the element in question two different ways.
