### PR TITLE
Correct error extraction from step function event

### DIFF
--- a/src/cirrus/lambda_functions/update_state.py
+++ b/src/cirrus/lambda_functions/update_state.py
@@ -167,7 +167,13 @@ def workflow_failed(
 
 
 def get_execution_error(event: dict) -> dict[str, str]:
-    return event["detail"].get("error") or DEFAULT_ERROR
+    error = event["detail"].get("error") or "Unknown"
+    cause = event["detail"].get("cause") or (
+        "No error cause was found in the event. Check that the 'Fail' state in the "
+        "workflow step function definition includes 'ErrorPath' and 'CausePath' fields "
+        "that capture the error name and error cause."
+    )
+    return {"Error": error, "Cause": cause}
 
 
 @WorkflowEventManager.with_wfem(logger=logger)


### PR DESCRIPTION
**Summary:**

The `get_execution_error` function in the `update_state.py` lambda function module assumed that error info was structured in the step function event `detail` as:

```
"detail": {
  ...
  "error": {
    "Error": "foo",
    "Cause": "bar"
  }
}
```

It is actually:
```
"detail": {
  ...
  "error": "foo",
  "cause": "bar"
  }
}
```

This assumption caused downstream code to attempt dictionary key access (`.get()`) on a string, causing the update-state lamdba to fail without updating the state database, which left the payload record in the state database with an incorrect status.

This PR:
1. Corrects the problem.
2. Adds an incrementally more informative error message when the `error` and `cause` keys are `null` in a step function event.
3. Updates the immediately relevant section in the docs.