### PR TITLE
Avoid editable installs in CI and lambda build

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
       - name: Install dependencies
-        run: uv sync --locked --group dev --extra cli
+        run: uv sync --locked --group dev --extra cli --no-editable
       - name: pre-commit
         run: uv run pre-commit run --all-files --verbose
       - name: Test with pytest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include requirements.txt
-recursive-include src *
-global-exclude *.py[cod]

--- a/bin/build-lambda-dist.bash
+++ b/bin/build-lambda-dist.bash
@@ -21,7 +21,7 @@ setup_venv() {
     venv="${1:?'provide path to directory for venv'}"
     uv venv "${venv}"
     source "${venv}/bin/activate"
-    uv sync --locked --no-dev --active
+    uv sync --locked --no-dev --active --no-editable
 }
 
 


### PR DESCRIPTION
- `uv`'s default editable install in the bash build script is causing deployed lambdas to fail (unable to find the cirrus installation). Fixed.
- Also avoiding the editable install in the CI test job.
- Removed leftover manifest file (no longer used).
