### PR TITLE
refactor(update-state): improve exception logging during event parsing

### DIFF
--- a/src/cirrus/lambda_functions/update_state.py
+++ b/src/cirrus/lambda_functions/update_state.py
@@ -92,7 +92,7 @@ class Execution:
                 error=error,
             )
         except Exception as e:
-            raise Exception(f"Unknown event: {json.dumps(event)}") from e
+            raise Exception(f"Error {e} | Unknown event: {json.dumps(event)}") from e
 
 
 def workflow_completed(


### PR DESCRIPTION
Currently, when `Execution.from_event` fails, the function catches the exception and re-raises a generic "Unknown event" error. This swallows the original stack trace and error type (e.g., TypeError), making debugging difficult.

This change logs the specific error message in the exception to improve observability.|

See: https://github.com/cirrus-geo/cirrus-geo/issues/355