### PR TITLE
feat(api): Support API Gateway v2 HTTP API events and configurable root path

### DIFF
--- a/docs/src/components/functions/api.rst
+++ b/docs/src/components/functions/api.rst
@@ -11,10 +11,30 @@ managers and handlers. The ``API`` lambda exists outside of the standard cirrus
 workflow as laid out in the architecture diagram in :doc:``cirrus_overview
 <../../cirrus/10_intro.rst>``
 
+Supported event formats
+-----------------------
+
+The handler supports both Lambda event payload formats:
+
+- **Payload format 1.0** — path read from ``event.path``
+- **Payload format 2.0** — path read from ``event.rawPath``
+
+When deployed with a route prefix (e.g. ``/cirrus``), set the
+``CIRRUS_API_GATEWAY_BASE_PATH`` environment variable to the prefix (without leading
+slash) so it is stripped before routing::
+
+    CIRRUS_API_GATEWAY_BASE_PATH=cirrus
+
+See `Lambda integration payload format versions
+<https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html>`_
+for details on the differences between format 1.0 and 2.0. Lambda Function
+URLs use `payload format version 2.0
+<https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html#urls-payloads>`_.
+
 Trigger
 -------
 
-Triggered by sending valid HTTTP requests.
+Triggered by sending valid HTTP requests.
 
 Query parameters can be included in HTTP requests to control the behavior of
 the response. A query param not in the following list will have no effect.

--- a/src/cirrus/lambda_functions/api.py
+++ b/src/cirrus/lambda_functions/api.py
@@ -283,7 +283,13 @@ def lambda_handler(event, _context):
     # get path parameters
     stage = event.get("requestContext", {}).get("stage", "")
 
-    parts = [p for p in event.get("path", "").split("/") if p != ""]
+    path_value = event.get("path") or event.get("rawPath", "")
+
+    base_path = os.getenv("CIRRUS_API_GATEWAY_BASE_PATH", "")
+    if base_path:
+        path_value = path_value.removeprefix(f"/{base_path}")
+
+    parts = [p for p in path_value.split("/") if p != ""]
     if len(parts) > 0 and parts[0] == stage:
         parts = parts[1:]
     payload_id = "/".join(parts)

--- a/tests/lambda_functions/test_api_lambda_handler.py
+++ b/tests/lambda_functions/test_api_lambda_handler.py
@@ -1,0 +1,202 @@
+import json
+
+from cirrus.lambda_functions import api
+from cirrus.lib.statedb import StateDB
+
+
+def _invoke(event):
+    resp = api.lambda_handler(event, {})
+    return resp["statusCode"], json.loads(resp["body"])
+
+
+def _make_rest_api_event(path, stage="$default", query_params=None):
+    """API Gateway REST API (v1) / payload format 1.0.
+
+    Uses top-level ``path`` and ``httpMethod``.
+    """
+    return {
+        "path": path,
+        "httpMethod": "GET",
+        "requestContext": {"stage": stage},
+        "queryStringParameters": query_params,
+    }
+
+
+def _make_http_api_event(raw_path, query_params=None):
+    """API Gateway HTTP API (v2) / Lambda Function URL / payload format 2.0.
+
+    Uses top-level ``rawPath`` and ``requestContext.http.method``.
+    Lambda Function URLs use the same payload format.
+    """
+    return {
+        "rawPath": raw_path,
+        "requestContext": {
+            "http": {"method": "GET", "path": raw_path},
+            "stage": "$default",
+        },
+        "queryStringParameters": query_params,
+    }
+
+
+class TestRestApiPayloadFormat:
+    """Routing with API Gateway REST API (payload format 1.0) events."""
+
+    def test_stats_route(self, monkeypatch):
+        monkeypatch.setattr(api, "get_stats", lambda **kw: {"ok": True})
+        status, body = _invoke(_make_rest_api_event("/stats"))
+        assert status == 200
+        assert body == {"ok": True}
+
+    def test_workflow_summary(self, monkeypatch):
+        monkeypatch.setattr(
+            api,
+            "summary",
+            lambda cw, since, limit, statedb: {
+                "collections": "mycol",
+                "workflow": "mywf",
+            },
+        )
+        status, body = _invoke(_make_rest_api_event("/mycol/workflow-mywf"))
+        assert status == 200
+        assert body == {"collections": "mycol", "workflow": "mywf"}
+
+    def test_workflow_items(self, monkeypatch):
+        monkeypatch.setattr(
+            StateDB,
+            "get_items_page",
+            lambda self, *a, **kw: {"items": []},
+        )
+        status, body = _invoke(
+            _make_rest_api_event(
+                "/mycol/workflow-mywf/items",
+                query_params={"state": "FAILED", "limit": "10"},
+            ),
+        )
+        assert status == 200
+        assert body == {"items": []}
+
+    def test_single_item(self, monkeypatch):
+        fake_item = {"id": "myitem123"}
+        monkeypatch.setattr(StateDB, "get_dbitem", lambda self, pid: fake_item)
+        monkeypatch.setattr(StateDB, "dbitem_to_item", lambda self, i: i)
+        monkeypatch.setattr(api, "to_current", lambda i: i)
+        status, body = _invoke(
+            _make_rest_api_event("/mycol/workflow-mywf/items/myitem123"),
+        )
+        assert status == 200
+        assert body == {"id": "myitem123"}
+
+    def test_stage_prefix_is_stripped(self, monkeypatch):
+        monkeypatch.setattr(api, "get_stats", lambda **kw: {"ok": True})
+        status, body = _invoke(
+            _make_rest_api_event("/somestage/stats", stage="somestage"),
+        )
+        assert status == 200
+        assert body == {"ok": True}
+
+    def test_query_params_forwarded(self, monkeypatch):
+        captured = {}
+
+        def fake_get_items_page(self, cw, **kwargs):
+            captured.update(kwargs)
+            return {"items": []}
+
+        monkeypatch.setattr(StateDB, "get_items_page", fake_get_items_page)
+        status, _body = _invoke(
+            _make_rest_api_event(
+                "/mycol/workflow-mywf/items",
+                query_params={
+                    "state": "COMPLETED",
+                    "since": "1d",
+                    "limit": "50",
+                    "sort_ascending": "1",
+                    "sort_index": "created",
+                    "nextkey": "abc",
+                },
+            ),
+        )
+        assert status == 200
+        assert captured["state"] == "COMPLETED"
+        assert captured["limit"] == 50
+        assert captured["sort_ascending"] is True
+        assert captured["sort_index"] == "created"
+        assert captured["nextkey"] == "abc"
+
+
+class TestHttpApiAndFunctionUrlPayloadFormat:
+    """Routing with HTTP API / Lambda Function URL (payload format 2.0) events."""
+
+    def test_stats_route(self, monkeypatch):
+        monkeypatch.setattr(api, "get_stats", lambda **kw: {"ok": True})
+        status, body = _invoke(_make_http_api_event("/stats"))
+        assert status == 200
+        assert body == {"ok": True}
+
+    def test_workflow_summary(self, monkeypatch):
+        monkeypatch.setattr(
+            api,
+            "summary",
+            lambda cw, since, limit, statedb: {
+                "collections": "mycol",
+                "workflow": "mywf",
+            },
+        )
+        status, body = _invoke(_make_http_api_event("/mycol/workflow-mywf"))
+        assert status == 200
+        assert body == {"collections": "mycol", "workflow": "mywf"}
+
+    def test_workflow_items_with_filters(self, monkeypatch):
+        monkeypatch.setattr(
+            StateDB,
+            "get_items_page",
+            lambda self, *a, **kw: {"items": []},
+        )
+        status, body = _invoke(
+            _make_http_api_event(
+                "/mycol/workflow-mywf/items",
+                query_params={"state": "FAILED", "limit": "10"},
+            ),
+        )
+        assert status == 200
+        assert body == {"items": []}
+
+
+class TestRootPathStripping:
+    """CIRRUS_API_GATEWAY_BASE_PATH strips a base path prefix before routing."""
+
+    def test_rest_api_strips_prefix(self, monkeypatch):
+        monkeypatch.setenv("CIRRUS_API_GATEWAY_BASE_PATH", "eoapi-cirrus")
+        monkeypatch.setattr(api, "get_stats", lambda **kw: {"ok": True})
+        status, body = _invoke(_make_rest_api_event("/eoapi-cirrus/stats"))
+        assert status == 200
+        assert body == {"ok": True}
+
+    def test_http_api_strips_prefix(self, monkeypatch):
+        monkeypatch.setenv("CIRRUS_API_GATEWAY_BASE_PATH", "eoapi-cirrus")
+        monkeypatch.setattr(api, "get_stats", lambda **kw: {"ok": True})
+        status, body = _invoke(_make_http_api_event("/eoapi-cirrus/stats"))
+        assert status == 200
+        assert body == {"ok": True}
+
+    def test_strips_prefix_from_workflow_path(self, monkeypatch):
+        monkeypatch.setenv("CIRRUS_API_GATEWAY_BASE_PATH", "myprefix")
+        monkeypatch.setattr(
+            api,
+            "summary",
+            lambda cw, since, limit, statedb: {
+                "collections": "collections",
+                "workflow": "wf",
+            },
+        )
+        status, body = _invoke(
+            _make_rest_api_event("/myprefix/collections/workflow-wf"),
+        )
+        assert status == 200
+        assert body == {"collections": "collections", "workflow": "wf"}
+
+    def test_no_env_var_preserves_default_behavior(self, monkeypatch):
+        monkeypatch.delenv("CIRRUS_API_GATEWAY_BASE_PATH", raising=False)
+        monkeypatch.setattr(api, "get_stats", lambda **kw: {"ok": True})
+        status, body = _invoke(_make_rest_api_event("/stats"))
+        assert status == 200
+        assert body == {"ok": True}


### PR DESCRIPTION
## Summary

- **Payload format 2.0 support**: `lambda_handler` now falls back to `event["rawPath"]` when `event["path"]` is absent, supporting HTTP APIs and Lambda Function URLs (payload format 2.0)
- **Configurable base path stripping**: New `CIRRUS_API_GATEWAY_BASE_PATH` env var strips an arbitrary base path prefix before routing — follows the same convention as Mangum's `api_gateway_base_path`
- **Non-breaking**: Payload format 1.0 events still have `path`, so existing deployments are unaffected

## Changes

- `src/cirrus/lambda_functions/api.py` — fall back to `rawPath`, strip `CIRRUS_API_GATEWAY_BASE_PATH` prefix
- `tests/lambda_functions/test_api_lambda_handler.py` — new dedicated test file with 13 tests
- `docs/src/components/functions/api.rst` — document supported event formats and base path config

## Test plan

- [x] Tests for payload format 1.0 routing (stats, workflow summary, items, single item, stage stripping, query param forwarding)
- [x] Tests for payload format 2.0 routing (stats, workflow summary, items with filters)
- [x] Tests for `CIRRUS_API_GATEWAY_BASE_PATH` stripping (both formats, workflow paths, no-env-var preserves behavior)
- [x] All 21 tests pass (8 pre-existing + 13 new)

## References

- [Lambda integration payload format versions](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html) — differences between format 1.0 and 2.0
- [Lambda Function URL payload format](https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html#urls-payloads) — uses payload format 2.0
- [REST API vs HTTP API comparison](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html)